### PR TITLE
Fixes compile error.

### DIFF
--- a/Source/PlatformNeutral/Networking/DBDelegate.h
+++ b/Source/PlatformNeutral/Networking/DBDelegate.h
@@ -2,6 +2,8 @@
 /// Copyright (c) 2016 Dropbox, Inc. All rights reserved.
 ///
 
+#import <Foundation/Foundation.h>
+
 @class DBRpcData;
 @class DBUploadData;
 @class DBDownloadData;


### PR DESCRIPTION
This commit fixes the compile error caused by not importing the `Foundation` framewrok.