### PR TITLE
Fixes another compile error.

### DIFF
--- a/Source/PlatformNeutral/Networking/DBHandlerTypes.h
+++ b/Source/PlatformNeutral/Networking/DBHandlerTypes.h
@@ -2,6 +2,8 @@
 /// Copyright (c) 2016 Dropbox, Inc. All rights reserved.
 ///
 
+#import <Foundation/Foundation.h>
+
 /// These are internal handler block types used by the SDK. The client-facing handler blocks
 /// look somewhat different.
 


### PR DESCRIPTION
This commit fixes another compile error caused by not importing the `Foundation` framework.