### PR TITLE
Allow passing of a cancel handler to the error presenter, and use it when offline.

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobile-iOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobile-iOS.m
@@ -54,7 +54,7 @@
                                                       style:(UIAlertActionStyle)UIAlertActionStyleCancel
                                                     handler:^(UIAlertAction *action){
 #pragma unused(action)
-                                                        void(^handler)(void) = buttonHandlers["Cancel"];
+                                                        void(^handler)(void) = buttonHandlers[@"Cancel"];
 
                                                         if (handler != nil) {
                                                             handler();
@@ -64,7 +64,7 @@
                                                       style:(UIAlertActionStyle)UIAlertActionStyleDefault
                                                     handler:^(UIAlertAction *action) {
 #pragma unused(action)
-                                                        void(^handler)(void) = buttonHandlers["Retry"];
+                                                        void(^handler)(void) = buttonHandlers[@"Retry"];
 
                                                         if (handler != nil) {
                                                             handler();

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobile-iOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobile-iOS.m
@@ -52,23 +52,23 @@
 
   [alertController addAction:[UIAlertAction actionWithTitle:@"Cancel"
                                                       style:(UIAlertActionStyle)UIAlertActionStyleCancel
-                                                    handler:^(UIAlertAction *action){
+                                                    handler:^(UIAlertAction *action) {
 #pragma unused(action)
-                                                        void(^handler)(void) = buttonHandlers[@"Cancel"];
+                                                      void (^handler)(void) = buttonHandlers[@"Cancel"];
 
-                                                        if (handler != nil) {
-                                                            handler();
-                                                        }
+                                                      if (handler != nil) {
+                                                        handler();
+                                                      }
                                                     }]];
   [alertController addAction:[UIAlertAction actionWithTitle:@"Retry"
                                                       style:(UIAlertActionStyle)UIAlertActionStyleDefault
                                                     handler:^(UIAlertAction *action) {
 #pragma unused(action)
-                                                        void(^handler)(void) = buttonHandlers[@"Retry"];
+                                                      void (^handler)(void) = buttonHandlers[@"Retry"];
 
-                                                        if (handler != nil) {
-                                                            handler();
-                                                        }
+                                                      if (handler != nil) {
+                                                        handler();
+                                                      }
                                                     }]];
 
   [_controller presentViewController:alertController

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobile-iOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobile-iOS.m
@@ -52,12 +52,23 @@
 
   [alertController addAction:[UIAlertAction actionWithTitle:@"Cancel"
                                                       style:(UIAlertActionStyle)UIAlertActionStyleCancel
-                                                    handler:nil]];
+                                                    handler:^(UIAlertAction *action){
+#pragma unused(action)
+                                                        void(^handler)(void) = buttonHandlers["Cancel"];
+
+                                                        if (handler != nil) {
+                                                            handler();
+                                                        }
+                                                    }]];
   [alertController addAction:[UIAlertAction actionWithTitle:@"Retry"
                                                       style:(UIAlertActionStyle)UIAlertActionStyleDefault
                                                     handler:^(UIAlertAction *action) {
 #pragma unused(action)
-                                                      buttonHandlers[@"Retry"]();
+                                                        void(^handler)(void) = buttonHandlers["Retry"];
+
+                                                        if (handler != nil) {
+                                                            handler();
+                                                        }
                                                     }]];
 
   [_controller presentViewController:alertController

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuth.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuth.m
@@ -74,60 +74,65 @@ static DBOAuthManager *sharedOAuthManager;
 }
 
 - (void)authorizeFromSharedApplication:(id<DBSharedApplication>)sharedApplication browserAuth:(BOOL)browserAuth {
-  if ([[DBSDKReachability reachabilityForInternetConnection] currentReachabilityStatus] == DBNotReachable) {
-    NSString *message = @"Try again once you have an internet connection.";
-    NSString *title = @"No internet connection";
+    void (^cancelHandler)() = ^{
+        NSURL *cancelUrl = [NSURL URLWithString:[NSString stringWithFormat:@"db-%@://2/cancel", _appKey]];
+        [sharedApplication presentExternalApp:cancelUrl];
+    };
 
-    NSDictionary<NSString *, void (^)()> *buttonHandlers =
-        @{ @"Retry" : ^void(){
-               [self authorizeFromSharedApplication:sharedApplication browserAuth:browserAuth];
-  }
-};
+    if ([[DBSDKReachability reachabilityForInternetConnection] currentReachabilityStatus] == DBNotReachable) {
+        NSString *message = @"Try again once you have an internet connection.";
+        NSString *title = @"No internet connection";
 
-[sharedApplication presentErrorMessageWithHandlers:message title:title buttonHandlers:buttonHandlers];
+        NSDictionary<NSString *, void (^)()> *buttonHandlers =
+        @{
+          @"Cancel": ^{
+              cancelHandler();
+          },
+          @"Retry": ^{
+              [self authorizeFromSharedApplication:sharedApplication browserAuth:browserAuth];
+          },
+          };
 
-return;
-}
+        [sharedApplication presentErrorMessageWithHandlers:message title:title buttonHandlers:buttonHandlers];
 
-if (![self conformsToAppScheme]) {
-  NSString *message = [NSString stringWithFormat:@"DropboxSDK: unable to link; app isn't registered for correct URL "
-                                                 @"scheme (db-%@). Add this scheme to your project Info.plist file, "
-                                                 @"associated with following key: \"Information Property List\" > "
-                                                 @"\"URL types\" > \"Item 0\" > \"URL Schemes\" > \"Item <N>\".",
-                                                 _appKey];
-  NSString *title = @"SwiftyDropbox Error";
-
-  [sharedApplication presentErrorMessage:message title:title];
-
-  return;
-}
-
-NSURL *url = [self authURL];
-
-if ([self checkAndPresentPlatformSpecificAuth:sharedApplication]) {
-  return;
-}
-
-if (browserAuth) {
-  [sharedApplication presentBrowserAuth:url];
-} else {
-  BOOL (^tryInterceptHandler)
-  (NSURL *) = ^BOOL(NSURL *url) {
-    if ([self canHandleURL:url]) {
-      [sharedApplication presentExternalApp:url];
-      return YES;
-    } else {
-      return NO;
+        return;
     }
-  };
 
-  void (^cancelHandler)() = ^void() {
-    NSURL *cancelUrl = [NSURL URLWithString:[NSString stringWithFormat:@"db-%@://2/cancel", _appKey]];
-    [sharedApplication presentExternalApp:cancelUrl];
-  };
+    if (![self conformsToAppScheme]) {
+        NSString *message = [NSString stringWithFormat:@"DropboxSDK: unable to link; app isn't registered for correct URL "
+                             @"scheme (db-%@). Add this scheme to your project Info.plist file, "
+                             @"associated with following key: \"Information Property List\" > "
+                             @"\"URL types\" > \"Item 0\" > \"URL Schemes\" > \"Item <N>\".",
+                             _appKey];
+        NSString *title = @"DropboxSDK Error";
 
-  [sharedApplication presentWebViewAuth:url tryInterceptHandler:tryInterceptHandler cancelHandler:cancelHandler];
-}
+        [sharedApplication presentErrorMessage:message title:title];
+
+        return;
+    }
+
+    NSURL *url = [self authURL];
+
+    if ([self checkAndPresentPlatformSpecificAuth:sharedApplication]) {
+        return;
+    }
+
+    if (browserAuth) {
+        [sharedApplication presentBrowserAuth:url];
+    } else {
+        BOOL (^tryInterceptHandler)
+        (NSURL *) = ^BOOL(NSURL *url) {
+            if ([self canHandleURL:url]) {
+                [sharedApplication presentExternalApp:url];
+                return YES;
+            } else {
+                return NO;
+            }
+        };
+
+
+        [sharedApplication presentWebViewAuth:url tryInterceptHandler:tryInterceptHandler cancelHandler:cancelHandler];
+    }
 }
 
 - (BOOL)conformsToAppScheme {

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuth.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuth.m
@@ -74,65 +74,63 @@ static DBOAuthManager *sharedOAuthManager;
 }
 
 - (void)authorizeFromSharedApplication:(id<DBSharedApplication>)sharedApplication browserAuth:(BOOL)browserAuth {
-    void (^cancelHandler)() = ^{
-        NSURL *cancelUrl = [NSURL URLWithString:[NSString stringWithFormat:@"db-%@://2/cancel", _appKey]];
-        [sharedApplication presentExternalApp:cancelUrl];
+  void (^cancelHandler)() = ^{
+    NSURL *cancelUrl = [NSURL URLWithString:[NSString stringWithFormat:@"db-%@://2/cancel", _appKey]];
+    [sharedApplication presentExternalApp:cancelUrl];
+  };
+
+  if ([[DBSDKReachability reachabilityForInternetConnection] currentReachabilityStatus] == DBNotReachable) {
+    NSString *message = @"Try again once you have an internet connection.";
+    NSString *title = @"No internet connection";
+
+    NSDictionary<NSString *, void (^)()> *buttonHandlers = @{
+      @"Cancel" : ^{
+        cancelHandler();
+      },
+      @"Retry" : ^{
+        [self authorizeFromSharedApplication:sharedApplication browserAuth:browserAuth];
+      },
     };
 
-    if ([[DBSDKReachability reachabilityForInternetConnection] currentReachabilityStatus] == DBNotReachable) {
-        NSString *message = @"Try again once you have an internet connection.";
-        NSString *title = @"No internet connection";
+    [sharedApplication presentErrorMessageWithHandlers:message title:title buttonHandlers:buttonHandlers];
 
-        NSDictionary<NSString *, void (^)()> *buttonHandlers =
-        @{
-          @"Cancel": ^{
-              cancelHandler();
-          },
-          @"Retry": ^{
-              [self authorizeFromSharedApplication:sharedApplication browserAuth:browserAuth];
-          },
-          };
+    return;
+  }
 
-        [sharedApplication presentErrorMessageWithHandlers:message title:title buttonHandlers:buttonHandlers];
+  if (![self conformsToAppScheme]) {
+    NSString *message = [NSString stringWithFormat:@"DropboxSDK: unable to link; app isn't registered for correct URL "
+                                                   @"scheme (db-%@). Add this scheme to your project Info.plist file, "
+                                                   @"associated with following key: \"Information Property List\" > "
+                                                   @"\"URL types\" > \"Item 0\" > \"URL Schemes\" > \"Item <N>\".",
+                                                   _appKey];
+    NSString *title = @"DropboxSDK Error";
 
-        return;
-    }
+    [sharedApplication presentErrorMessage:message title:title];
 
-    if (![self conformsToAppScheme]) {
-        NSString *message = [NSString stringWithFormat:@"DropboxSDK: unable to link; app isn't registered for correct URL "
-                             @"scheme (db-%@). Add this scheme to your project Info.plist file, "
-                             @"associated with following key: \"Information Property List\" > "
-                             @"\"URL types\" > \"Item 0\" > \"URL Schemes\" > \"Item <N>\".",
-                             _appKey];
-        NSString *title = @"DropboxSDK Error";
+    return;
+  }
 
-        [sharedApplication presentErrorMessage:message title:title];
+  NSURL *url = [self authURL];
 
-        return;
-    }
+  if ([self checkAndPresentPlatformSpecificAuth:sharedApplication]) {
+    return;
+  }
 
-    NSURL *url = [self authURL];
+  if (browserAuth) {
+    [sharedApplication presentBrowserAuth:url];
+  } else {
+    BOOL (^tryInterceptHandler)
+    (NSURL *) = ^BOOL(NSURL *url) {
+      if ([self canHandleURL:url]) {
+        [sharedApplication presentExternalApp:url];
+        return YES;
+      } else {
+        return NO;
+      }
+    };
 
-    if ([self checkAndPresentPlatformSpecificAuth:sharedApplication]) {
-        return;
-    }
-
-    if (browserAuth) {
-        [sharedApplication presentBrowserAuth:url];
-    } else {
-        BOOL (^tryInterceptHandler)
-        (NSURL *) = ^BOOL(NSURL *url) {
-            if ([self canHandleURL:url]) {
-                [sharedApplication presentExternalApp:url];
-                return YES;
-            } else {
-                return NO;
-            }
-        };
-
-
-        [sharedApplication presentWebViewAuth:url tryInterceptHandler:tryInterceptHandler cancelHandler:cancelHandler];
-    }
+    [sharedApplication presentWebViewAuth:url tryInterceptHandler:tryInterceptHandler cancelHandler:cancelHandler];
+  }
 }
 
 - (BOOL)conformsToAppScheme {


### PR DESCRIPTION
This fixes an issue where we don't indicate that the user cancelled when there is no internet connection and they decline to retry.