### PR TITLE
Add disable signup parameter to DBOAuthManager

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuth.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuth.h
@@ -140,6 +140,10 @@
 ///
 - (BOOL)clearStoredAccessTokens;
 
+///
+///
+@property (nonatomic, assign) BOOL disableSignup;
+
 @end
 
 #pragma mark - OAuth manager base (macOS)

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuth.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuth.h
@@ -141,7 +141,10 @@
 - (BOOL)clearStoredAccessTokens;
 
 ///
-///
+/// When NO, the Dropbox web login page will show a sign up link below the
+/// form.
+/// When YES, the Dropbox web login page will show a 'Get the App' link instead.
+/// The default value is YES.
 @property (nonatomic, assign) BOOL disableSignup;
 
 @end

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuth.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuth.h
@@ -141,10 +141,15 @@
 - (BOOL)clearStoredAccessTokens;
 
 ///
-/// When NO, the Dropbox web login page will show a sign up link below the
-/// form.
-/// When YES, the Dropbox web login page will show a 'Get the App' link instead.
-/// The default value is YES.
+/// When YES users will not be able to sign up for a Dropbox account via the authorization page.
+/// Instead, the authorization page will show a link to the Dropbox iOS app in the App Store.
+/// This is was originally intended for use when necessary for compliance with App Store policies.
+///
+/// Default value is YES.
+/// 
+/// NOTE: Recent App Store policy suggests that sign up is now allowed, so it should be safe to
+/// enable signup. However we are keeping the parameter and defaulting to YES to allow SDK users
+/// to make the appropriate decision for their apps.
 @property (nonatomic, assign) BOOL disableSignup;
 
 @end

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuth.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuth.m
@@ -47,6 +47,7 @@ static DBOAuthManager *sharedOAuthManager;
     _redirectURL = [[NSURL alloc] initWithString:[NSString stringWithFormat:@"db-%@://2/token", _appKey]];
     _host = host;
     _urls = [NSMutableArray arrayWithObjects:_redirectURL, nil];
+    _disableSignup = YES;
   }
   return self;
 }
@@ -159,7 +160,7 @@ static DBOAuthManager *sharedOAuthManager;
     [NSURLQueryItem queryItemWithName:@"response_type" value:@"token"],
     [NSURLQueryItem queryItemWithName:@"client_id" value:_appKey],
     [NSURLQueryItem queryItemWithName:@"redirect_uri" value:[_redirectURL absoluteString]],
-    [NSURLQueryItem queryItemWithName:@"disable_signup" value:@"true"],
+    [NSURLQueryItem queryItemWithName:@"disable_signup" value:self.disableSignup ? @"true": @"false"],
   ];
   return components.URL;
 }


### PR DESCRIPTION
Allows clients to control whether or not the ‘Sign Up’ link or the ‘Get the App’ link is shown on the dropbox login page.