### PR TITLE
Fixed Token Migration

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBSDKKeychain.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBSDKKeychain.m
@@ -181,6 +181,10 @@ static const char *kV1OSXAccountName = "Dropbox";
                            responseBlock:responseBlock
                                    queue:queueToUse];
       }];
+    } else {
+      [queueToUse addOperationWithBlock:^{
+        responseBlock(NO, NO, @[]);
+      }];
     }
   } else {
     [queueToUse addOperationWithBlock:^{


### PR DESCRIPTION
`responseBlock` is called if token migration hasn't occurred yet and won't be performed. Related issue: #117