### PR TITLE
[AgileBits/1Password] Convert auth tokens on defined NSOperationQueues

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBSDKKeychain.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBSDKKeychain.m
@@ -174,7 +174,7 @@ static const char *kV1OSXAccountName = "Dropbox";
 #endif
 
     if ([v1TokensData count] > 0) {
-      [[NSOperationQueue new] addOperationWithBlock:^{
+      [[self v1TokenConversionOperationQueue] addOperationWithBlock:^{
         [[self class] convertV1TokenToV2:v1TokensData
                                   appKey:appKey
                                appSecret:appSecret
@@ -430,7 +430,7 @@ static const char *kV1OSXAccountName = "Dropbox";
           }
           dispatch_group_leave(tokenConvertGroup);
         }
-                   queue:[NSOperationQueue new]];
+                   queue:[self rpcTaskOperationQueue]];
   }
 
   // wait for all token conversion calls to complete and then update the keychain, and call the response block
@@ -447,6 +447,32 @@ static const char *kV1OSXAccountName = "Dropbox";
       responseBlock(shouldRetry, invalidAppKeyOrSecret, unsuccessfullyMigratedTokenData);
     }];
   });
+}
+
+#pragma mark - Operation Queues
+
+static NSOperationQueue *_v1TokenConversionOperationQueue = nil;
++ (NSOperationQueue *)v1TokenConversionOperationQueue {
+    static dispatch_once_t tokenConversionOnceToken;
+    dispatch_once(&tokenConversionOnceToken, ^{
+        _v1TokenConversionOperationQueue = [[NSOperationQueue alloc] init];
+        _v1TokenConversionOperationQueue.name = [NSString stringWithFormat:@"%@ %@", NSStringFromClass(self.class), NSStringFromSelector(_cmd)];
+        _v1TokenConversionOperationQueue.qualityOfService = NSQualityOfServiceUtility;
+    });
+
+    return _v1TokenConversionOperationQueue;
+}
+
+static NSOperationQueue *_rpcTaskOperationQueue = nil;
++ (NSOperationQueue *)rpcTaskOperationQueue {
+    static dispatch_once_t rpcTaskOnceToken;
+    dispatch_once(&rpcTaskOnceToken, ^{
+        _rpcTaskOperationQueue = [[NSOperationQueue alloc] init];
+        _rpcTaskOperationQueue.name = [NSString stringWithFormat:@"%@ %@", NSStringFromClass(self.class), NSStringFromSelector(_cmd)];
+        _rpcTaskOperationQueue.qualityOfService = NSQualityOfServiceUtility;
+    });
+
+    return _rpcTaskOperationQueue;
 }
 
 @end


### PR DESCRIPTION
## Reason to Be

Prior to this change the token conversion was spawning a new unowned operation queue for each conversion and each token RPC task. While this worked, the behavior of creating and using operation queues in this manner is undefined. We now have defined operation queues for each part of the conversion.

## Thought Process

I didn't want to load up a single operation queue with all the operations so instead I defined two: one for the conversions, and one for the RPC tasks. Since we're dealing with class methods here these are static operation queues that are created once, on demand.

The one semi-significant change I made was to the quality of service of the queues themselves. By default `NSOperationQueue` has a `qualityOfService` of `NSOperationQualityOfServiceBackground`. We've found some significant delays in operations run at this QoS, so I bumped it up to `NSQualityOfServiceUtility`. From the docs:

> Used for performing work which the user is unlikely to be immediately waiting for the results. This work may have been requested by the user or initiated automatically, and often operates at user-visible timescales using a non-modal progress indicator. For example, periodic content updates or bulk file operations, such as media import.

We could consider bumping this up further to `NSQualityOfServiceUserInitiated`, but given that we were running with `NSOperationQualityOfServiceBackground` before, we're probably OK here.

## How To Test

Run the tests, make sure they pass.

## Possible Impacts

Deadlocks, mayhem, dogs and cats living together. (It's probably just fine, but please do check my work).