### PR TITLE
[AgileBits/1Password] Don’t dismiss unpresented view controllers

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobile-iOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobile-iOS.m
@@ -110,8 +110,10 @@ static DBMobileSharedApplication *s_mobileSharedApplication;
 }
 
 - (void)dismissAuthController {
-  if (_controller) {
-    [_controller dismissViewControllerAnimated:YES completion:nil];
+  if (_controller != nil) {
+    if (_controller.presentedViewController != nil && _controller.presentedViewController.isBeingDismissed == NO && [_controller.presentedViewController isKindOfClass:[DBMobileSafariViewController class]]) {
+      [_controller dismissViewControllerAnimated:YES completion:nil];
+    }
   }
 }
 


### PR DESCRIPTION
## Reason to Be

When using the Dropbox app to authorize access, the in-app auth view is not being presented. However, when we return to the app it was indiscriminately dismissing any presented view controllers it had. In the case of 1Password, this was a view controller we were presenting to setup Dropbox sync. Additionally, in certain other cases it was over-dismissing the presented view controller, resulting in more than one view controller being dismissed.

## CHANGELOG Entry

> [FIXED] View controllers that were not presented by the Dropbox SDK are no longer being dismissed during the authorization process.

## Thought Process

It took a bit of debugging to drill down to the solution for this one. In the end it ended up being a combination of a few things:

1. When dismissing a view controller we have to make sure there is a presented view controller to dismiss.
2. The presented view controller should be of a type that we would have presented (in this case the `DBMobileSafariViewController`).
3. Before dismissing the presented view controller we need to make sure it's not already being dismissed.

## How To Test

There are a number of tests to perform to make sure this didn't break anything else:

1. Install the Dropbox app and use it to authorize access to a test app.
2. Delete the Dropbox app and use the embedded `DBMobileSafariViewController` to perform the authorization. Ensure you can:
-- Tap the Done button to close the `DBMobileSafariViewController`
-- Tap the **Cancel** button in the web view.
-- Tap the **Allow** button in the web view.

## Possible Impacts

Given the multitude of ways that authorization can take place this change could have adverse effects somewhere. However, given the checks performed before we dismiss the `DBMobileSafariViewController` I think we're in good shape.

## Testing Checklist

```
- [ ] Run the test suite and ensure it all passes.
```