### PR TITLE
Obey -Wstrict-prototypes

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Headers/Internal/Networking/DBHandlerTypesInternal.h
+++ b/Source/ObjectiveDropboxOfficial/Headers/Internal/Networking/DBHandlerTypesInternal.h
@@ -26,4 +26,4 @@ typedef void (^DBDownloadUrlResponseBlockImpl)(id _Nullable, id _Nullable, DBReq
 
 typedef void (^DBDownloadDataResponseBlockImpl)(id _Nullable, id _Nullable, DBRequestError *_Nullable,
                                                 NSData *_Nullable);
-typedef void (^DBCleanupBlock)();
+typedef void (^DBCleanupBlock)(void);

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobile-iOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobile-iOS.m
@@ -53,7 +53,7 @@ static DBMobileSharedApplication *s_mobileSharedApplication;
 
 - (void)presentErrorMessageWithHandlers:(NSString *)message
                                   title:(NSString *)title
-                         buttonHandlers:(NSDictionary<NSString *, void (^)()> *)buttonHandlers {
+                         buttonHandlers:(NSDictionary<NSString *, void (^)(void)> *)buttonHandlers {
   UIAlertController *alertController =
       [UIAlertController alertControllerWithTitle:title
                                           message:message

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.m
@@ -92,7 +92,7 @@ static DBOAuthManager *s_sharedOAuthManager;
 }
 
 - (void)authorizeFromSharedApplication:(id<DBSharedApplication>)sharedApplication {
-  void (^cancelHandler)() = ^{
+  void (^cancelHandler)(void) = ^{
     [sharedApplication presentExternalApp:self->_cancelURL];
   };
 
@@ -102,7 +102,7 @@ static DBOAuthManager *s_sharedOAuthManager;
     NSString *title = NSLocalizedString(@"No internet connection",
                                         @"Displayed when commencing authorization flow without internet connection.");
 
-    NSDictionary<NSString *, void (^)()> *buttonHandlers = @{
+    NSDictionary<NSString *, void (^)(void)> *buttonHandlers = @{
       @"Cancel" : ^{
         cancelHandler();
       },

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBSharedApplicationProtocol.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBSharedApplicationProtocol.h
@@ -32,7 +32,7 @@ typedef void (^DBOAuthCancelBlock)(void);
 ///
 - (void)presentErrorMessageWithHandlers:(NSString *)message
                                   title:(NSString *)title
-                         buttonHandlers:(NSDictionary<NSString *, void (^)()> *)buttonHandlers;
+                         buttonHandlers:(NSDictionary<NSString *, void (^)(void)> *)buttonHandlers;
 
 ///
 /// Presents platform-specific authorization paths.


### PR DESCRIPTION
Xcode 9 suggests enabling clang's `-Wstrict-prototypes`. This diff fixes cases about which that warning complains.