### PR TITLE
Adding ability to set a custom hostname for oauth flow

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBClientsManager+MobileAuth-iOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBClientsManager+MobileAuth-iOS.m
@@ -31,8 +31,9 @@
 }
 
 + (void)setupWithTransportConfig:(DBTransportDefaultConfig *)transportConfig {
-  [[self class] setupWithOAuthManager:[[DBOAuthMobileManager alloc] initWithAppKey:transportConfig.appKey]
-                      transportConfig:transportConfig];
+    [[self class] setupWithOAuthManager:[[DBOAuthMobileManager alloc] initWithAppKey:transportConfig.appKey
+                                                                                host:transportConfig.hostname]
+                        transportConfig:transportConfig];
 }
 
 + (void)setupWithTeamAppKey:(NSString *)appKey {
@@ -40,8 +41,9 @@
 }
 
 + (void)setupWithTeamTransportConfig:(DBTransportDefaultConfig *)transportConfig {
-  [[self class] setupWithOAuthManagerTeam:[[DBOAuthMobileManager alloc] initWithAppKey:transportConfig.appKey]
-                          transportConfig:transportConfig];
+    [[self class] setupWithOAuthManagerTeam:[[DBOAuthMobileManager alloc] initWithAppKey:transportConfig.appKey
+                                                                                    host:transportConfig.hostname]
+                            transportConfig:transportConfig];
 }
 
 @end

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBClientsManager+DesktopAuth-macOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBClientsManager+DesktopAuth-macOS.m
@@ -29,8 +29,9 @@
 }
 
 + (void)setupWithTransportConfigDesktop:(DBTransportDefaultConfig *)transportConfig {
-  [[self class] setupWithOAuthManager:[[DBOAuthManager alloc] initWithAppKey:transportConfig.appKey]
-                      transportConfig:transportConfig];
+    [[self class] setupWithOAuthManager:[[DBOAuthManager alloc] initWithAppKey:transportConfig.appKey
+                                                                          host:transportConfig.hostname]
+                        transportConfig:transportConfig];
 }
 
 + (void)setupWithTeamAppKeyDesktop:(NSString *)appKey {
@@ -38,8 +39,9 @@
 }
 
 + (void)setupWithTeamTransportConfigDesktop:(DBTransportDefaultConfig *)transportConfig {
-  [[self class] setupWithOAuthManagerTeam:[[DBOAuthManager alloc] initWithAppKey:transportConfig.appKey]
-                          transportConfig:transportConfig];
+    [[self class] setupWithOAuthManagerTeam:[[DBOAuthManager alloc] initWithAppKey:transportConfig.appKey
+                                                                              host:transportConfig.hostname]
+                            transportConfig:transportConfig];
 }
 
 @end

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseConfig.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseConfig.h
@@ -19,6 +19,10 @@ NS_ASSUME_NONNULL_BEGIN
 /// querying endpoints the have "app auth" authentication type.
 @property (nonatomic, readonly, copy, nullable) NSString *appSecret;
 
+/// The hostname used for oauth networking requests. Leave as nil to use the default, otherwise can be set to a custom
+///  value for debugging purposes.
+@property (nonatomic, readonly, copy, nullable) NSString *hostname;
+
 /// The user agent associated with all networking requests. Used for server logging.
 @property (nonatomic, readonly, copy, nullable) NSString *userAgent;
 
@@ -89,6 +93,29 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 - (instancetype)initWithAppKey:(nullable NSString *)appKey
                      appSecret:(nullable NSString *)appSecret
+                     userAgent:(nullable NSString *)userAgent
+                    asMemberId:(nullable NSString *)asMemberId
+             additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders;
+
+///
+/// Full constructor, with debug hostname override.
+///
+/// @param appKey The consumer app key associated with the app that is integrating with the Dropbox API. Here, app key
+/// is used for querying endpoints the have "app auth" authentication type.
+/// @param appSecret The consumer app secret associated with the app that is integrating with the Dropbox API. Here, app
+/// key is used for querying endpoints the have "app auth" authentication type.
+/// @param hostname A custom hostname to use for networking requests. Only useful for debugging purposes and only
+/// affects the oauth flows at this time.
+/// @param userAgent The user agent associated with all networking requests. Used for server logging.
+/// @param asMemberId An additional authentication header field used when a team app with the appropriate permissions
+/// "performs" user API actions on behalf of a team member.
+/// @param additionalHeaders Additional HTTP headers to be injected into each client request.
+///
+/// @return An initialized instance.
+///
+- (instancetype)initWithAppKey:(nullable NSString *)appKey
+                     appSecret:(nullable NSString *)appSecret
+                      hostname:(nullable NSString *)hostname
                      userAgent:(nullable NSString *)userAgent
                     asMemberId:(nullable NSString *)asMemberId
              additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders;

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseConfig.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseConfig.m
@@ -27,10 +27,25 @@
                      userAgent:(NSString *)userAgent
                     asMemberId:(NSString *)asMemberId
              additionalHeaders:(NSDictionary<NSString *, NSString *> *)additionalHeaders {
+  return [self initWithAppKey:appKey
+                    appSecret:appSecret
+                     hostname:nil
+                    userAgent:userAgent
+                   asMemberId:asMemberId
+            additionalHeaders:additionalHeaders];
+}
+
+- (instancetype)initWithAppKey:(nullable NSString *)appKey
+                     appSecret:(nullable NSString *)appSecret
+                      hostname:(nullable NSString *)hostname
+                     userAgent:(nullable NSString *)userAgent
+                    asMemberId:(nullable NSString *)asMemberId
+             additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders {
   if (self = [super init]) {
     _userAgent = userAgent;
     _appKey = appKey;
     _appSecret = appSecret;
+    _hostname = hostname;
     _asMemberId = asMemberId;
     _additionalHeaders = additionalHeaders;
   }

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportDefaultConfig.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportDefaultConfig.h
@@ -186,6 +186,38 @@ NS_ASSUME_NONNULL_BEGIN
         forceForegroundSession:(BOOL)forceForegroundSession
      sharedContainerIdentifier:(nullable NSString *)sharedContainerIdentifier;
 
+///
+/// Full constructor, with debug hostname override.
+///
+/// @param appKey The consumer app key associated with the app that is integrating with the Dropbox API. Here, app key
+/// is used for querying endpoints that have "app auth" authentication type.
+/// @param appSecret The consumer app secret associated with the app that is integrating with the Dropbox API. Here, app
+/// key is used for querying endpoints that have "app auth" authentication type.
+/// @param hostname A custom hostname to use for networking requests. Only useful for debugging purposes and only
+/// affects the oauth flows at this time.
+/// @param userAgent The user agent associated with all networking requests. Used for server logging.
+/// @param delegateQueue A serial delegate queue used for executing blocks of code that touch state shared across
+/// threads (mainly the request handlers storage).
+/// @param forceForegroundSession If set to true, all network requests are made on foreground sessions (by default, most
+/// upload/download operations are performed with a background session).
+/// @param asMemberId An additional authentication header field used when a team app with the appropriate permissions
+/// "performs" user API actions on behalf of a team member.
+/// @param sharedContainerIdentifier The identifier for the shared container into which files in background URL sessions
+/// should be downloaded. This needs to be set when downloading via an app extension.
+/// @param additionalHeaders Additional HTTP headers to be injected into each client request.
+///
+/// @return An initialized instance.
+///
+- (instancetype)initWithAppKey:(NSString *)appKey
+                     appSecret:(nullable NSString *)appSecret
+                      hostname:(nullable NSString *)hostname
+                     userAgent:(nullable NSString *)userAgent
+                    asMemberId:(nullable NSString *)asMemberId
+             additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders
+                 delegateQueue:(nullable NSOperationQueue *)delegateQueue
+        forceForegroundSession:(BOOL)forceForegroundSession
+     sharedContainerIdentifier:(nullable NSString *)sharedContainerIdentifier;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportDefaultConfig.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportDefaultConfig.m
@@ -85,16 +85,37 @@
                  delegateQueue:(NSOperationQueue *)delegateQueue
         forceForegroundSession:(BOOL)forceForegroundSession
      sharedContainerIdentifier:(NSString *)sharedContainerIdentifier {
-  if (self = [super initWithAppKey:appKey
-                         appSecret:appSecret
-                         userAgent:userAgent
-                        asMemberId:asMemberId
-                 additionalHeaders:additionalHeaders]) {
-    _delegateQueue = delegateQueue;
-    _forceForegroundSession = forceForegroundSession;
-    _sharedContainerIdentifier = sharedContainerIdentifier;
-  }
-  return self;
+    return [self initWithAppKey:appKey
+                      appSecret:appSecret
+                       hostname:nil
+                      userAgent:userAgent
+                     asMemberId:asMemberId
+              additionalHeaders:additionalHeaders
+                  delegateQueue:delegateQueue
+         forceForegroundSession:forceForegroundSession
+      sharedContainerIdentifier:sharedContainerIdentifier];
+}
+
+- (instancetype)initWithAppKey:(NSString *)appKey
+                     appSecret:(nullable NSString *)appSecret
+                      hostname:(nullable NSString *)hostname
+                     userAgent:(nullable NSString *)userAgent
+                    asMemberId:(nullable NSString *)asMemberId
+             additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders
+                 delegateQueue:(nullable NSOperationQueue *)delegateQueue
+        forceForegroundSession:(BOOL)forceForegroundSession
+     sharedContainerIdentifier:(nullable NSString *)sharedContainerIdentifier {
+    if (self = [super initWithAppKey:appKey
+                           appSecret:appSecret
+                            hostname:hostname
+                           userAgent:userAgent
+                          asMemberId:asMemberId
+                   additionalHeaders:additionalHeaders]) {
+        _delegateQueue = delegateQueue;
+        _forceForegroundSession = forceForegroundSession;
+        _sharedContainerIdentifier = sharedContainerIdentifier;
+    }
+    return self;
 }
 
 @end

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.h
@@ -93,11 +93,11 @@ NS_ASSUME_NONNULL_BEGIN
 /// `DBOAuthManager` full constructor.
 ///
 /// @param appKey The app key from the developer console that identifies this app.
-/// @param host The host of the OAuth web flow.
+/// @param host The host of the OAuth web flow. Leave nil to use default host.
 ///
 /// @return An initialized instance.
 ///
-- (instancetype)initWithAppKey:(NSString *)appKey host:(NSString *)host;
+- (instancetype)initWithAppKey:(NSString *)appKey host:(nullable NSString *)host;
 
 #pragma mark - Auth flow methods
 

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.m
@@ -48,14 +48,17 @@ static DBOAuthManager *s_sharedOAuthManager;
 #pragma mark - Constructors
 
 - (instancetype)initWithAppKey:(NSString *)appKey {
-  NSString *hostToUse =
-      !kSDKDebug ? @"www.dropbox.com" : [NSString stringWithFormat:@"meta-%@.dev.corp.dropbox.com", kSDKDebugHost];
-  return [self initWithAppKey:appKey host:hostToUse];
+  return [self initWithAppKey:appKey host:nil];
 }
 
-- (instancetype)initWithAppKey:(NSString *)appKey host:(NSString *)host {
+- (instancetype)initWithAppKey:(NSString *)appKey host:(nullable NSString *)host {
   self = [super init];
   if (self) {
+      if (host == nil) {
+          host =
+          !kSDKDebug ? @"www.dropbox.com" : [NSString stringWithFormat:@"meta-%@.dev.corp.dropbox.com", kSDKDebugHost];
+      }
+
     _appKey = appKey;
     _redirectURL = [[NSURL alloc] initWithString:[NSString stringWithFormat:@"db-%@://2/token", _appKey]];
     _cancelURL = [NSURL URLWithString:[NSString stringWithFormat:@"db-%@://2/cancel", _appKey]];


### PR DESCRIPTION
This is useful when wanting to debug flows with a custom oauth hostname. Allows the app to pass in the hostname instead of needing to override `kSDKDebug` and `kSDKDebugHost`. This solution isn't perfect because `kSDKDebugHost` is also used in `DBTransportBaseClient.m` which calcualted 3 different hostnames (api, content, notify). Allowing for those to be customized would require a more through change and likely a new struct to hold the 3 different hostnames properly.

I decided to focus on just the oauth hostname here since it's needed to do more easier testing within the Paper app.
