### PR TITLE
Adding a `DBTransportBaseHostnameConfig` object to configure all hostnames

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Headers/Internal/Networking/DBTransportBaseClient+Internal.h
+++ b/Source/ObjectiveDropboxOfficial/Headers/Internal/Networking/DBTransportBaseClient+Internal.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
                                     content:(nullable NSData *)content
                                      stream:(nullable NSInputStream *)stream;
 
-+ (NSURL *)urlWithRoute:(DBRoute *)route;
+- (NSURL *)urlWithRoute:(DBRoute *)route;
 
 + (NSData *)serializeDataWithRoute:(DBRoute *)route routeArg:(id<DBSerializable>)arg;
 

--- a/Source/ObjectiveDropboxOfficial/ObjectiveDropboxOfficial.xcodeproj/project.pbxproj
+++ b/Source/ObjectiveDropboxOfficial/ObjectiveDropboxOfficial.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3C3C29741F7D757E00C54011 /* DBTransportBaseHostnameConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C3C29721F7D757E00C54011 /* DBTransportBaseHostnameConfig.m */; };
+		3C3C29751F7D757E00C54011 /* DBTransportBaseHostnameConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C3C29721F7D757E00C54011 /* DBTransportBaseHostnameConfig.m */; };
+		3C3C29761F7D758E00C54011 /* DBTransportBaseHostnameConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C3C29731F7D757E00C54011 /* DBTransportBaseHostnameConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3C3C29771F7D758E00C54011 /* DBTransportBaseHostnameConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C3C29731F7D757E00C54011 /* DBTransportBaseHostnameConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F235B5221E29913600144F8B /* DBOAuthMobile-iOS.m in Sources */ = {isa = PBXBuildFile; fileRef = F235B51C1E29913600144F8B /* DBOAuthMobile-iOS.m */; };
 		F235B5241E29913600144F8B /* DBClientsManager+MobileAuth-iOS.m in Sources */ = {isa = PBXBuildFile; fileRef = F235B51E1E29913600144F8B /* DBClientsManager+MobileAuth-iOS.m */; };
 		F235B52F1E29915400144F8B /* DBOAuthDesktop-macOS.m in Sources */ = {isa = PBXBuildFile; fileRef = F235B5291E29915400144F8B /* DBOAuthDesktop-macOS.m */; };
@@ -2155,6 +2159,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3C3C29721F7D757E00C54011 /* DBTransportBaseHostnameConfig.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DBTransportBaseHostnameConfig.m; sourceTree = "<group>"; };
+		3C3C29731F7D757E00C54011 /* DBTransportBaseHostnameConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DBTransportBaseHostnameConfig.h; sourceTree = "<group>"; };
 		F235B51B1E29913600144F8B /* DBOAuthMobile-iOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "DBOAuthMobile-iOS.h"; sourceTree = "<group>"; };
 		F235B51C1E29913600144F8B /* DBOAuthMobile-iOS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "DBOAuthMobile-iOS.m"; sourceTree = "<group>"; };
 		F235B51D1E29913600144F8B /* DBClientsManager+MobileAuth-iOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "DBClientsManager+MobileAuth-iOS.h"; sourceTree = "<group>"; };
@@ -3404,6 +3410,8 @@
 				F297818A1E03692800876A73 /* DBTransportBaseClient.m */,
 				F24169491E5247D60038E306 /* DBTransportBaseConfig.h */,
 				F241694A1E5247D60038E306 /* DBTransportBaseConfig.m */,
+				3C3C29731F7D757E00C54011 /* DBTransportBaseHostnameConfig.h */,
+				3C3C29721F7D757E00C54011 /* DBTransportBaseHostnameConfig.m */,
 				F297818B1E03692800876A73 /* DBTransportClientProtocol.h */,
 				F29781871E03692800876A73 /* DBTransportDefaultClient.h */,
 				F29781881E03692800876A73 /* DBTransportDefaultClient.m */,
@@ -4881,6 +4889,7 @@
 				F2984B7F1F70F7620014DC65 /* DBTEAMUserCustomQuotaArg.h in Headers */,
 				F2984C271F70F7620014DC65 /* DBTEAMLOGFileCommentNotificationPolicy.h in Headers */,
 				F2984B671F70F7620014DC65 /* DBTEAMTeamGetInfoResult.h in Headers */,
+				3C3C29761F7D758E00C54011 /* DBTransportBaseHostnameConfig.h in Headers */,
 				F2984E431F70F7630014DC65 /* DBTEAMLOGTfaRemoveBackupPhoneDetails.h in Headers */,
 				F2984D9D1F70F7630014DC65 /* DBTEAMLOGSharedContentRemoveLinkPasswordDetails.h in Headers */,
 				F298497F1F70F7610014DC65 /* DBSHARINGListFileMembersContinueError.h in Headers */,
@@ -5851,6 +5860,7 @@
 				F2984E7E1F70F7630014DC65 /* DBUSERSAccount.h in Headers */,
 				F2984E7A1F70F7630014DC65 /* DBTEAMPOLICIESTeamSharingPolicies.h in Headers */,
 				F2984E781F70F7630014DC65 /* DBTEAMPOLICIESTeamMemberPolicies.h in Headers */,
+				3C3C29771F7D758E00C54011 /* DBTransportBaseHostnameConfig.h in Headers */,
 				F2984E761F70F7630014DC65 /* DBTEAMPOLICIESSsoPolicy.h in Headers */,
 				F2984E741F70F7630014DC65 /* DBTEAMPOLICIESSharedLinkCreatePolicy.h in Headers */,
 				F2984E721F70F7630014DC65 /* DBTEAMPOLICIESSharedFolderMemberPolicy.h in Headers */,
@@ -6939,6 +6949,7 @@
 				F2984EEF1F70F7640014DC65 /* DBFILEREQUESTSRouteObjects.m in Sources */,
 				F29847C71F70F7610014DC65 /* DBFilesObjects.m in Sources */,
 				F2984EC31F70F7640014DC65 /* DBFILEPROPERTIESTeamAuthRoutes.m in Sources */,
+				3C3C29741F7D757E00C54011 /* DBTransportBaseHostnameConfig.m in Sources */,
 				F2984EDF1F70F7640014DC65 /* DBTEAMTeamAuthRoutes.m in Sources */,
 				F29788C91E03692F00876A73 /* DBClientsManager.m in Sources */,
 				F29849031F70F7610014DC65 /* DBSharingObjects.m in Sources */,
@@ -7040,6 +7051,7 @@
 				F2984B941F70F7620014DC65 /* DBTeamLogObjects.m in Sources */,
 				F2984EE41F70F7640014DC65 /* DBUSERSUserAuthRoutes.m in Sources */,
 				F29847AA1F70F7610014DC65 /* DBFileRequestsObjects.m in Sources */,
+				3C3C29751F7D757E00C54011 /* DBTransportBaseHostnameConfig.m in Sources */,
 				F2984EC01F70F7640014DC65 /* DBAUTHUserAuthRoutes.m in Sources */,
 				F2984ECC1F70F7640014DC65 /* DBFILEREQUESTSUserAuthRoutes.m in Sources */,
 				F2A2CEA21E562FEB001D8449 /* DBCustomDatatypes.m in Sources */,

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBClientsManager+MobileAuth-iOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBClientsManager+MobileAuth-iOS.m
@@ -31,8 +31,9 @@
 }
 
 + (void)setupWithTransportConfig:(DBTransportDefaultConfig *)transportConfig {
-    [[self class] setupWithOAuthManager:[[DBOAuthMobileManager alloc] initWithAppKey:transportConfig.appKey
-                                                                                host:transportConfig.hostname]
+    [[self class] setupWithOAuthManager:[[DBOAuthMobileManager alloc]
+                                         initWithAppKey:transportConfig.appKey
+                                         host:transportConfig.hostnameConfig.meta]
                         transportConfig:transportConfig];
 }
 
@@ -41,8 +42,9 @@
 }
 
 + (void)setupWithTeamTransportConfig:(DBTransportDefaultConfig *)transportConfig {
-    [[self class] setupWithOAuthManagerTeam:[[DBOAuthMobileManager alloc] initWithAppKey:transportConfig.appKey
-                                                                                    host:transportConfig.hostname]
+    [[self class] setupWithOAuthManagerTeam:[[DBOAuthMobileManager alloc]
+                                             initWithAppKey:transportConfig.appKey
+                                             host:transportConfig.hostnameConfig.meta]
                             transportConfig:transportConfig];
 }
 

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBClientsManager+DesktopAuth-macOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBClientsManager+DesktopAuth-macOS.m
@@ -30,7 +30,7 @@
 
 + (void)setupWithTransportConfigDesktop:(DBTransportDefaultConfig *)transportConfig {
     [[self class] setupWithOAuthManager:[[DBOAuthManager alloc] initWithAppKey:transportConfig.appKey
-                                                                          host:transportConfig.hostname]
+                                                                          host:transportConfig.hostnameConfig.meta]
                         transportConfig:transportConfig];
 }
 
@@ -40,7 +40,7 @@
 
 + (void)setupWithTeamTransportConfigDesktop:(DBTransportDefaultConfig *)transportConfig {
     [[self class] setupWithOAuthManagerTeam:[[DBOAuthManager alloc] initWithAppKey:transportConfig.appKey
-                                                                              host:transportConfig.hostname]
+                                                                              host:transportConfig.hostnameConfig.meta]
                             transportConfig:transportConfig];
 }
 

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseClient.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseClient.m
@@ -16,29 +16,11 @@
 
 #pragma mark - Internal serialization helpers
 
-NSDictionary<NSString *, NSString *> *kV2SDKBaseHosts;
+@interface DBTransportBaseClient ()
+@property (nonatomic, readonly, copy) DBTransportBaseHostnameConfig *hostnameConfig;
+@end
 
 @implementation DBTransportBaseClient
-
-+ (void)initialize {
-  static dispatch_once_t once;
-  dispatch_once(&once, ^{
-    if (!kSDKDebug) {
-      kV2SDKBaseHosts = @{
-        @"api" : @"https://api.dropbox.com/2",
-        @"content" : @"https://api-content.dropbox.com/2",
-        @"notify" : @"https://notify.dropboxapi.com/2",
-      };
-    } else {
-      kV2SDKBaseHosts = @{
-        @"api" : [NSString stringWithFormat:@"https://api-%@.dev.corp.dropbox.com/2", kSDKDebugHost],
-        @"content" : [NSString stringWithFormat:@"https://api-content-%@.dev.corp.dropbox.com/2", kSDKDebugHost],
-        @"notify" : [NSString stringWithFormat:@"https://notify-%@.dev.corp.dropboxapi.com/2", kSDKDebugHost],
-      };
-    }
-
-  });
-}
 
 - (instancetype)initWithAccessToken:(NSString *)accessToken
                            tokenUid:(NSString *)tokenUid
@@ -48,6 +30,7 @@ NSDictionary<NSString *, NSString *> *kV2SDKBaseHosts;
     _tokenUid = [tokenUid copy];
     _appKey = transportConfig.appKey;
     _appSecret = transportConfig.appSecret;
+    _hostnameConfig = transportConfig.hostnameConfig;
     NSString *defaultUserAgent = [NSString stringWithFormat:@"%@/%@", kV2SDKDefaultUserAgentPrefix, kV2SDKVersion];
     _userAgent = transportConfig.userAgent ? [[transportConfig.userAgent stringByAppendingString:@"/"]
                                                  stringByAppendingString:defaultUserAgent]
@@ -140,9 +123,9 @@ NSDictionary<NSString *, NSString *> *kV2SDKBaseHosts;
   return request;
 }
 
-+ (NSURL *)urlWithRoute:(DBRoute *)route {
-  return [NSURL URLWithString:[NSString stringWithFormat:@"%@/%@/%@", kV2SDKBaseHosts[route.attrs[@"host"]],
-                                                         route.namespace_, route.name]];
+- (NSURL *)urlWithRoute:(DBRoute *)route {
+  NSString *routePrefix = [_hostnameConfig apiV2PrefixWithRouteType:route.attrs[@"host"]];
+  return [NSURL URLWithString:[NSString stringWithFormat:@"%@/%@/%@", routePrefix, route.namespace_, route.name]];
 }
 
 + (NSData *)serializeDataWithRoute:(DBRoute *)route routeArg:(id<DBSerializable>)arg {

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseConfig.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseConfig.h
@@ -4,6 +4,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import "DBTransportBaseHostnameConfig.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 ///
@@ -19,9 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// querying endpoints the have "app auth" authentication type.
 @property (nonatomic, readonly, copy, nullable) NSString *appSecret;
 
-/// The hostname used for oauth networking requests. Leave as nil to use the default, otherwise can be set to a custom
-///  value for debugging purposes.
-@property (nonatomic, readonly, copy, nullable) NSString *hostname;
+/// The hostname configuration used for various networking requests.
+@property (nonatomic, readonly, copy) DBTransportBaseHostnameConfig *hostnameConfig;
 
 /// The user agent associated with all networking requests. Used for server logging.
 @property (nonatomic, readonly, copy, nullable) NSString *userAgent;
@@ -104,8 +105,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// is used for querying endpoints the have "app auth" authentication type.
 /// @param appSecret The consumer app secret associated with the app that is integrating with the Dropbox API. Here, app
 /// key is used for querying endpoints the have "app auth" authentication type.
-/// @param hostname A custom hostname to use for networking requests. Only useful for debugging purposes and only
-/// affects the oauth flows at this time.
+/// @param hostnameConfig A set of custom hostnames to use for networking requests. Only useful for debugging purposes.
 /// @param userAgent The user agent associated with all networking requests. Used for server logging.
 /// @param asMemberId An additional authentication header field used when a team app with the appropriate permissions
 /// "performs" user API actions on behalf of a team member.
@@ -115,7 +115,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 - (instancetype)initWithAppKey:(nullable NSString *)appKey
                      appSecret:(nullable NSString *)appSecret
-                      hostname:(nullable NSString *)hostname
+                hostnameConfig:(nullable DBTransportBaseHostnameConfig *)hostnameConfig
                      userAgent:(nullable NSString *)userAgent
                     asMemberId:(nullable NSString *)asMemberId
              additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders;

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseConfig.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseConfig.m
@@ -29,7 +29,7 @@
              additionalHeaders:(NSDictionary<NSString *, NSString *> *)additionalHeaders {
   return [self initWithAppKey:appKey
                     appSecret:appSecret
-                     hostname:nil
+               hostnameConfig:nil
                     userAgent:userAgent
                    asMemberId:asMemberId
             additionalHeaders:additionalHeaders];
@@ -37,7 +37,7 @@
 
 - (instancetype)initWithAppKey:(nullable NSString *)appKey
                      appSecret:(nullable NSString *)appSecret
-                      hostname:(nullable NSString *)hostname
+                hostnameConfig:(nullable DBTransportBaseHostnameConfig *)hostnameConfig
                      userAgent:(nullable NSString *)userAgent
                     asMemberId:(nullable NSString *)asMemberId
              additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders {
@@ -45,7 +45,7 @@
     _userAgent = userAgent;
     _appKey = appKey;
     _appSecret = appSecret;
-    _hostname = hostname;
+    _hostnameConfig = hostnameConfig ?: [[DBTransportBaseHostnameConfig alloc] init];
     _asMemberId = asMemberId;
     _additionalHeaders = additionalHeaders;
   }

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseHostnameConfig.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseHostnameConfig.h
@@ -1,0 +1,50 @@
+///
+/// Copyright (c) 2017 Dropbox, Inc. All rights reserved.
+///
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+///
+/// Configuration class that defines the different hostnames that the Dropbox SDK uses
+///
+@interface DBTransportBaseHostnameConfig : NSObject
+
+@property (nonatomic, readonly, copy) NSString *meta;
+@property (nonatomic, readonly, copy) NSString *api;
+@property (nonatomic, readonly, copy) NSString *content;
+@property (nonatomic, readonly, copy) NSString *notify;
+
+///
+/// Default constructor.
+///
+/// @return An initialized instance of hostname configurations with default values set for all hostnames
+///
+- (instancetype)init;
+
+///
+/// Constructor that takes in a set of custom hostnames to use for api calls.
+///
+/// @param meta the hostname to metaserver
+/// @param api the hostname to api server
+/// @param content the hostname to content server
+/// @param notify the hostname to notify server
+///
+/// @return An initialized instance with the provided hostname configuration
+///
+- (instancetype)initWithMeta:(NSString *)meta api:(NSString *)api content:(NSString *)content notify:(NSString *)notify;
+
+///
+/// Returns the prefix to use for API calls to the given route type.
+///
+/// @param routeType the type of route to get a prefix for.
+/// Currently the valid values are: "api", "content", and "notify".
+///
+/// @return An absolute URL prefix, typically "https://<hostname>/2" or nil if an invalid route type is provided.
+///
+- (nullable NSString *)apiV2PrefixWithRouteType:(NSString *)routeType;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseHostnameConfig.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseHostnameConfig.m
@@ -1,0 +1,50 @@
+///
+/// Copyright (c) 2016 Dropbox, Inc. All rights reserved.
+///
+
+#import "DBSDKConstants.h"
+#import "DBTransportBaseHostnameConfig.h"
+
+@implementation DBTransportBaseHostnameConfig
+
+- (instancetype)init {
+    if (!kSDKDebug) {
+        return [self initWithMeta:@"www.dropbox.com"
+                              api:@"api.dropbox.com"
+                          content:@"api-content.dropbox.com"
+                           notify:@"notify.dropboxapi.com"];
+    } else {
+        return [self initWithMeta:[NSString stringWithFormat:@"meta-%@.dev.corp.dropbox.com", kSDKDebugHost]
+                              api:[NSString stringWithFormat:@"api-%@.dev.corp.dropbox.com", kSDKDebugHost]
+                          content:[NSString stringWithFormat:@"api-content-%@.dev.corp.dropbox.com", kSDKDebugHost]
+                           notify:[NSString stringWithFormat:@"notify-%@.dev.corp.dropboxapi.com", kSDKDebugHost]];
+    }
+    return self;
+}
+
+- (instancetype)initWithMeta:(NSString *)meta
+                         api:(NSString *)api
+                     content:(NSString *)content
+                      notify:(NSString *)notify {
+    if (self == [super init]) {
+        _meta = meta;
+        _api = api;
+        _content = content;
+        _notify = notify;
+    }
+    return self;
+}
+
+- (nullable NSString *)apiV2PrefixWithRouteType:(NSString *)routeType {
+    if ([routeType isEqualToString:@"api"]) {
+        return [NSString stringWithFormat:@"https://%@/2", _api];
+    } else if ([routeType isEqualToString:@"content"]) {
+        return [NSString stringWithFormat:@"https://%@/2", _content];
+    } else if ([routeType isEqualToString:@"notify"]) {
+        return [NSString stringWithFormat:@"https://%@/2", _notify];
+    } else {
+        return nil;
+    }
+}
+
+@end

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportDefaultClient.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportDefaultClient.m
@@ -86,7 +86,7 @@
 #pragma mark - RPC-style request
 
 - (DBRpcTaskImpl *)requestRpc:(DBRoute *)route arg:(id<DBSerializable>)arg {
-  NSURL *requestUrl = [[self class] urlWithRoute:route];
+  NSURL *requestUrl = [self urlWithRoute:route];
   NSString *serializedArg = [[self class] serializeStringWithRoute:route routeArg:arg];
   NSDictionary *headers = [self headersWithRouteInfo:route.attrs serializedArg:serializedArg];
 
@@ -117,7 +117,7 @@
 
 - (DBUploadTaskImpl *)requestUpload:(DBRoute *)route arg:(id<DBSerializable>)arg inputUrl:(NSString *)input {
   NSURL *inputUrl = [NSURL fileURLWithPath:input];
-  NSURL *requestUrl = [[self class] urlWithRoute:route];
+  NSURL *requestUrl = [self urlWithRoute:route];
   NSString *serializedArg = [[self class] serializeStringWithRoute:route routeArg:arg];
   NSDictionary *headers = [self headersWithRouteInfo:route.attrs serializedArg:serializedArg];
 
@@ -139,7 +139,7 @@
 #pragma mark - Upload-style request (NSData)
 
 - (DBUploadTaskImpl *)requestUpload:(DBRoute *)route arg:(id<DBSerializable>)arg inputData:(NSData *)input {
-  NSURL *requestUrl = [[self class] urlWithRoute:route];
+  NSURL *requestUrl = [self urlWithRoute:route];
   NSString *serializedArg = [[self class] serializeStringWithRoute:route routeArg:arg];
   NSDictionary *headers = [self headersWithRouteInfo:route.attrs serializedArg:serializedArg];
 
@@ -161,7 +161,7 @@
 #pragma mark - Upload-style request (NSInputStream)
 
 - (DBUploadTaskImpl *)requestUpload:(DBRoute *)route arg:(id<DBSerializable>)arg inputStream:(NSInputStream *)input {
-  NSURL *requestUrl = [[self class] urlWithRoute:route];
+  NSURL *requestUrl = [self urlWithRoute:route];
   NSString *serializedArg = [[self class] serializeStringWithRoute:route routeArg:arg];
   NSDictionary *headers = [self headersWithRouteInfo:route.attrs serializedArg:serializedArg];
 
@@ -200,7 +200,7 @@
                            destination:(NSURL *)destination
                        byteOffsetStart:(NSNumber *)byteOffsetStart
                          byteOffsetEnd:(NSNumber *)byteOffsetEnd {
-  NSURL *requestUrl = [[self class] urlWithRoute:route];
+  NSURL *requestUrl = [self urlWithRoute:route];
   NSString *serializedArg = [[self class] serializeStringWithRoute:route routeArg:arg];
   NSDictionary *headers = [self headersWithRouteInfo:route.attrs
                                        serializedArg:serializedArg
@@ -232,7 +232,7 @@
                                     arg:(id<DBSerializable>)arg
                         byteOffsetStart:(NSNumber *)byteOffsetStart
                           byteOffsetEnd:(NSNumber *)byteOffsetEnd {
-  NSURL *requestUrl = [[self class] urlWithRoute:route];
+  NSURL *requestUrl = [self urlWithRoute:route];
   NSString *serializedArg = [[self class] serializeStringWithRoute:route routeArg:arg];
   NSDictionary *headers = [self headersWithRouteInfo:route.attrs
                                        serializedArg:serializedArg

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportDefaultConfig.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportDefaultConfig.h
@@ -193,8 +193,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// is used for querying endpoints that have "app auth" authentication type.
 /// @param appSecret The consumer app secret associated with the app that is integrating with the Dropbox API. Here, app
 /// key is used for querying endpoints that have "app auth" authentication type.
-/// @param hostname A custom hostname to use for networking requests. Only useful for debugging purposes and only
-/// affects the oauth flows at this time.
+/// @param hostnameConfig A custom hostname to use for networking requests. Only useful for debugging purposes.
 /// @param userAgent The user agent associated with all networking requests. Used for server logging.
 /// @param delegateQueue A serial delegate queue used for executing blocks of code that touch state shared across
 /// threads (mainly the request handlers storage).
@@ -210,7 +209,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 - (instancetype)initWithAppKey:(NSString *)appKey
                      appSecret:(nullable NSString *)appSecret
-                      hostname:(nullable NSString *)hostname
+                hostnameConfig:(nullable DBTransportBaseHostnameConfig *)hostnameConfig
                      userAgent:(nullable NSString *)userAgent
                     asMemberId:(nullable NSString *)asMemberId
              additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportDefaultConfig.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportDefaultConfig.m
@@ -87,7 +87,7 @@
      sharedContainerIdentifier:(NSString *)sharedContainerIdentifier {
     return [self initWithAppKey:appKey
                       appSecret:appSecret
-                       hostname:nil
+                 hostnameConfig:nil
                       userAgent:userAgent
                      asMemberId:asMemberId
               additionalHeaders:additionalHeaders
@@ -98,7 +98,7 @@
 
 - (instancetype)initWithAppKey:(NSString *)appKey
                      appSecret:(nullable NSString *)appSecret
-                      hostname:(nullable NSString *)hostname
+                hostnameConfig:(nullable DBTransportBaseHostnameConfig *)hostnameConfig
                      userAgent:(nullable NSString *)userAgent
                     asMemberId:(nullable NSString *)asMemberId
              additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders
@@ -107,7 +107,7 @@
      sharedContainerIdentifier:(nullable NSString *)sharedContainerIdentifier {
     if (self = [super initWithAppKey:appKey
                            appSecret:appSecret
-                            hostname:hostname
+                      hostnameConfig:hostnameConfig
                            userAgent:userAgent
                           asMemberId:asMemberId
                    additionalHeaders:additionalHeaders]) {


### PR DESCRIPTION
This is a followup to #170 that improves it by allowing an override of all 4 hostnames that the SDK uses.

I tested this change on the Dropbox app and the Paper app and it works well (once a few private uses of `urlWithRoute:` are fixed up to not use the class method version).