### PR TITLE
Rename `caseInsensitiveLookupWithKey:dictionary:` and make it a bit safer

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Headers/Internal/Networking/DBTransportBaseClient+Internal.h
+++ b/Source/ObjectiveDropboxOfficial/Headers/Internal/Networking/DBTransportBaseClient+Internal.h
@@ -47,8 +47,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BOOL)statusCodeIsRouteError:(int)statusCode;
 
-+ (nullable NSString *)caseInsensitiveLookupWithKey:(nullable NSString *)lookupKey
-                                         dictionary:(NSDictionary<id, id> *_Nullable)dictionary;
+/**
+ *  This method performs a lookup for the passed in @p lookupKey on the given @p headerFieldsDictionary. However, since
+ *  HTTP header field keys are case insensitive, it compares the keys in the dictionary to @p lookupKey in a case
+ *  insensitive way.
+ *
+ *  @param lookupKey              The key that we want to fetch from the header dictionary. Irrespective of case
+ *  @param headerFieldsDictionary HTTP headers fiels dictionary (e.g. the result of calling allHeaderFields in an
+ *                                NSHTTPURLResponse instance)
+ *
+ *  @return The value corresponding to the passed in @p lookupKey or nil if none is found.
+ */
++ (nullable id)caseInsensitiveLookupWithKey:(nullable NSString *)lookupKey
+                     headerFieldsDictionary:(nullable NSDictionary<id, id> *)headerFieldsDictionary;
 
 + (NSString *)sdkVersion;
 

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasks.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasks.m
@@ -284,9 +284,14 @@
     NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
     int statusCode = (int)httpResponse.statusCode;
     NSDictionary *httpHeaders = httpResponse.allHeaderFields;
-    NSString *headerString =
-        [DBTransportBaseClient caseInsensitiveLookupWithKey:@"Dropbox-API-Result" dictionary:httpHeaders];
-    NSData *resultData = headerString ? [headerString dataUsingEncoding:NSUTF8StringEncoding] : nil;
+    id headerString = [DBTransportBaseClient caseInsensitiveLookupWithKey:@"Dropbox-API-Result"
+                                                   headerFieldsDictionary:httpHeaders];
+
+    NSData *resultData = nil;
+    if ([headerString isKindOfClass:[NSString class]]) {
+      // If `headerString == nil` then `resultData = nil`
+      resultData = [headerString dataUsingEncoding:NSUTF8StringEncoding];
+    }
 
     DBRoute *route = strongSelf->_route;
 
@@ -402,9 +407,14 @@
     NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
     int statusCode = (int)httpResponse.statusCode;
     NSDictionary *httpHeaders = httpResponse.allHeaderFields;
-    NSString *headerString =
-        [DBTransportBaseClient caseInsensitiveLookupWithKey:@"Dropbox-API-Result" dictionary:httpHeaders];
-    NSData *resultData = headerString ? [headerString dataUsingEncoding:NSUTF8StringEncoding] : nil;
+    id headerString = [DBTransportBaseClient caseInsensitiveLookupWithKey:@"Dropbox-API-Result"
+                                                   headerFieldsDictionary:httpHeaders];
+
+    NSData *resultData = nil;
+    if ([headerString isKindOfClass:[NSString class]]) {
+      // If `headerString == nil` then `resultData = nil`
+      resultData = [headerString dataUsingEncoding:NSUTF8StringEncoding];
+    }
 
     DBRoute *route = strongSelf->_route;
 

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseClient.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseClient.m
@@ -326,11 +326,15 @@
   return statusCode == 409;
 }
 
-+ (NSString *)caseInsensitiveLookupWithKey:(NSString *)lookupKey dictionary:(NSDictionary<id, id> *)dictionary {
-  for (id key in dictionary) {
-    NSString *keyString = (NSString *)key;
-    if ([keyString.lowercaseString isEqualToString:lookupKey.lowercaseString]) {
-      return (NSString *)dictionary[key];
++ (nullable id)caseInsensitiveLookupWithKey:(nullable NSString *)lookupKey
+                     headerFieldsDictionary:(nullable NSDictionary<id, id> *)headerFieldsDictionary {
+  NSString *lowercaseLookupKey = lookupKey.lowercaseString;
+  for (id key in headerFieldsDictionary) {
+    if ([key isKindOfClass:[NSString class]]) {
+      NSString *keyString = (NSString *)key;
+      if ([keyString.lowercaseString isEqualToString:lowercaseLookupKey]) {
+        return headerFieldsDictionary[key];
+      }
     }
   }
   return nil;


### PR DESCRIPTION
Renamed `caseInsensitiveLookupWithKey:dictionary:` to `caseInsensitiveLookupWithKey:headerFieldsDictionary:` and made the method a bit safer by not crashing if any of the keys are not an `NSString`.

Also added documentation to the method and changed the return value to be `id` since we don't have any guarantees there. That means that the callers to it need to be changed to perform a check.