### PR TITLE
support redirect url in oauth manager

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBClientsManager+MobileAuth-iOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBClientsManager+MobileAuth-iOS.m
@@ -32,7 +32,8 @@
 
 + (void)setupWithTransportConfig:(DBTransportDefaultConfig *)transportConfig {
   [[self class] setupWithOAuthManager:[[DBOAuthMobileManager alloc] initWithAppKey:transportConfig.appKey
-                                                                              host:transportConfig.hostnameConfig.meta]
+                                                                              host:transportConfig.hostnameConfig.meta
+                                                                       redirectURL:transportConfig.redirectURL]
                       transportConfig:transportConfig];
 }
 
@@ -43,7 +44,8 @@
 + (void)setupWithTeamTransportConfig:(DBTransportDefaultConfig *)transportConfig {
   [[self class]
       setupWithOAuthManagerTeam:[[DBOAuthMobileManager alloc] initWithAppKey:transportConfig.appKey
-                                                                        host:transportConfig.hostnameConfig.meta]
+                                                                        host:transportConfig.hostnameConfig.meta
+                                                                 redirectURL:transportConfig.redirectURL]
                 transportConfig:transportConfig];
 }
 

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseConfig.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseConfig.h
@@ -24,6 +24,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// The hostname configuration used for various networking requests.
 @property (nonatomic, readonly, copy, nullable) DBTransportBaseHostnameConfig *hostnameConfig;
 
+/// The redirect url used for oauth flow
+@property (nonatomic, readonly, copy, nullable) NSString *redirectURL;
+
 /// The user agent associated with all networking requests. Used for server logging.
 @property (nonatomic, readonly, copy, nullable) NSString *userAgent;
 
@@ -116,6 +119,30 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithAppKey:(nullable NSString *)appKey
                      appSecret:(nullable NSString *)appSecret
                 hostnameConfig:(nullable DBTransportBaseHostnameConfig *)hostnameConfig
+                     userAgent:(nullable NSString *)userAgent
+                    asMemberId:(nullable NSString *)asMemberId
+             additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders;
+
+///
+/// Full constructor, with debug hostname and redirectURL override.
+///
+/// @param appKey The consumer app key associated with the app that is integrating with the Dropbox API. Here, app key
+/// is used for querying endpoints the have "app auth" authentication type.
+/// @param appSecret The consumer app secret associated with the app that is integrating with the Dropbox API. Here, app
+/// key is used for querying endpoints the have "app auth" authentication type.
+/// @param hostnameConfig A set of custom hostnames to use for networking requests. Only useful for debugging purposes.
+/// @param redirectURL The redirect url used for oauth flow.
+/// @param userAgent The user agent associated with all networking requests. Used for server logging.
+/// @param asMemberId An additional authentication header field used when a team app with the appropriate permissions
+/// "performs" user API actions on behalf of a team member.
+/// @param additionalHeaders Additional HTTP headers to be injected into each client request.
+///
+/// @return An initialized instance.
+///
+- (instancetype)initWithAppKey:(nullable NSString *)appKey
+                     appSecret:(nullable NSString *)appSecret
+                hostnameConfig:(nullable DBTransportBaseHostnameConfig *)hostnameConfig
+                   redirectURL:(nullable NSString *)redirectURL
                      userAgent:(nullable NSString *)userAgent
                     asMemberId:(nullable NSString *)asMemberId
              additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders;

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseConfig.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseConfig.m
@@ -41,10 +41,27 @@
                      userAgent:(NSString *)userAgent
                     asMemberId:(NSString *)asMemberId
              additionalHeaders:(NSDictionary<NSString *, NSString *> *)additionalHeaders {
+    return [self initWithAppKey:appKey
+                      appSecret:appSecret
+                 hostnameConfig:hostnameConfig
+                    redirectURL:nil
+                      userAgent:userAgent
+                     asMemberId:asMemberId
+              additionalHeaders:additionalHeaders];
+}
+
+- (instancetype)initWithAppKey:(NSString *)appKey
+                     appSecret:(NSString *)appSecret
+                hostnameConfig:(DBTransportBaseHostnameConfig *)hostnameConfig
+                   redirectURL:(NSString *)redirectURL
+                     userAgent:(NSString *)userAgent
+                    asMemberId:(NSString *)asMemberId
+             additionalHeaders:(NSDictionary<NSString *,NSString *> *)additionalHeaders {
   if (self = [super init]) {
     _userAgent = userAgent;
     _appKey = appKey;
     _appSecret = appSecret;
+    _redirectURL = redirectURL;
     _hostnameConfig = hostnameConfig;
     _asMemberId = asMemberId;
     _additionalHeaders = additionalHeaders;

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportDefaultConfig.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportDefaultConfig.h
@@ -217,6 +217,38 @@ NS_ASSUME_NONNULL_BEGIN
         forceForegroundSession:(BOOL)forceForegroundSession
      sharedContainerIdentifier:(nullable NSString *)sharedContainerIdentifier;
 
+///
+/// Full constructor, with debug hostname and redirectURL override.
+///
+/// @param appKey The consumer app key associated with the app that is integrating with the Dropbox API. Here, app key
+/// is used for querying endpoints that have "app auth" authentication type.
+/// @param appSecret The consumer app secret associated with the app that is integrating with the Dropbox API. Here, app
+/// key is used for querying endpoints that have "app auth" authentication type.
+/// @param hostnameConfig A custom hostname to use for networking requests. Only useful for debugging purposes.
+/// @param userAgent The user agent associated with all networking requests. Used for server logging.
+/// @param delegateQueue A serial delegate queue used for executing blocks of code that touch state shared across
+/// threads (mainly the request handlers storage).
+/// @param forceForegroundSession If set to true, all network requests are made on foreground sessions (by default, most
+/// upload/download operations are performed with a background session).
+/// @param asMemberId An additional authentication header field used when a team app with the appropriate permissions
+/// "performs" user API actions on behalf of a team member.
+/// @param sharedContainerIdentifier The identifier for the shared container into which files in background URL sessions
+/// should be downloaded. This needs to be set when downloading via an app extension.
+/// @param additionalHeaders Additional HTTP headers to be injected into each client request.
+///
+/// @return An initialized instance.
+///
+- (instancetype)initWithAppKey:(NSString *)appKey
+                     appSecret:(nullable NSString *)appSecret
+                hostnameConfig:(nullable DBTransportBaseHostnameConfig *)hostnameConfig
+                   redirectURL:(nullable NSString *)redirectURL
+                     userAgent:(nullable NSString *)userAgent
+                    asMemberId:(nullable NSString *)asMemberId
+             additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders
+                 delegateQueue:(nullable NSOperationQueue *)delegateQueue
+        forceForegroundSession:(BOOL)forceForegroundSession
+     sharedContainerIdentifier:(nullable NSString *)sharedContainerIdentifier;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportDefaultConfig.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportDefaultConfig.m
@@ -97,14 +97,14 @@
 }
 
 - (instancetype)initWithAppKey:(NSString *)appKey
-                     appSecret:(nullable NSString *)appSecret
-                hostnameConfig:(nullable DBTransportBaseHostnameConfig *)hostnameConfig
-                     userAgent:(nullable NSString *)userAgent
-                    asMemberId:(nullable NSString *)asMemberId
-             additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders
-                 delegateQueue:(nullable NSOperationQueue *)delegateQueue
+                     appSecret:(NSString *)appSecret
+                hostnameConfig:(DBTransportBaseHostnameConfig *)hostnameConfig
+                     userAgent:(NSString *)userAgent
+                    asMemberId:(NSString *)asMemberId
+             additionalHeaders:(NSDictionary<NSString *, NSString *> *)additionalHeaders
+                 delegateQueue:(NSOperationQueue *)delegateQueue
         forceForegroundSession:(BOOL)forceForegroundSession
-     sharedContainerIdentifier:(nullable NSString *)sharedContainerIdentifier {
+     sharedContainerIdentifier:(NSString *)sharedContainerIdentifier {
     return [self initWithAppKey:appKey
                       appSecret:appSecret
                  hostnameConfig:hostnameConfig
@@ -118,15 +118,15 @@
 }
 
 - (instancetype)initWithAppKey:(NSString *)appKey
-                     appSecret:(nullable NSString *)appSecret
-                hostnameConfig:(nullable DBTransportBaseHostnameConfig *)hostnameConfig
-                   redirectURL:(nullable NSString *)redirectURL
-                     userAgent:(nullable NSString *)userAgent
-                    asMemberId:(nullable NSString *)asMemberId
-             additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders
-                 delegateQueue:(nullable NSOperationQueue *)delegateQueue
+                     appSecret:(NSString *)appSecret
+                hostnameConfig:(DBTransportBaseHostnameConfig *)hostnameConfig
+                   redirectURL:(NSString *)redirectURL
+                     userAgent:(NSString *)userAgent
+                    asMemberId:(NSString *)asMemberId
+             additionalHeaders:(NSDictionary<NSString *, NSString *> *)additionalHeaders
+                 delegateQueue:(NSOperationQueue *)delegateQueue
         forceForegroundSession:(BOOL)forceForegroundSession
-     sharedContainerIdentifier:(nullable NSString *)sharedContainerIdentifier {
+     sharedContainerIdentifier:(NSString *)sharedContainerIdentifier {
     if (self = [super initWithAppKey:appKey
                            appSecret:appSecret
                       hostnameConfig:hostnameConfig 

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportDefaultConfig.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportDefaultConfig.m
@@ -105,16 +105,39 @@
                  delegateQueue:(nullable NSOperationQueue *)delegateQueue
         forceForegroundSession:(BOOL)forceForegroundSession
      sharedContainerIdentifier:(nullable NSString *)sharedContainerIdentifier {
-  if (self = [super initWithAppKey:appKey
-                         appSecret:appSecret
-                    hostnameConfig:hostnameConfig
-                         userAgent:userAgent
-                        asMemberId:asMemberId
-                 additionalHeaders:additionalHeaders]) {
-    _delegateQueue = delegateQueue;
-    _forceForegroundSession = forceForegroundSession;
-    _sharedContainerIdentifier = sharedContainerIdentifier;
-  }
+    return [self initWithAppKey:appKey
+                      appSecret:appSecret
+                 hostnameConfig:hostnameConfig
+                    redirectURL:nil
+                      userAgent:userAgent
+                     asMemberId:asMemberId
+              additionalHeaders:additionalHeaders
+                  delegateQueue:delegateQueue
+         forceForegroundSession:forceForegroundSession
+      sharedContainerIdentifier:sharedContainerIdentifier];
+}
+
+- (instancetype)initWithAppKey:(NSString *)appKey
+                     appSecret:(nullable NSString *)appSecret
+                hostnameConfig:(nullable DBTransportBaseHostnameConfig *)hostnameConfig
+                   redirectURL:(nullable NSString *)redirectURL
+                     userAgent:(nullable NSString *)userAgent
+                    asMemberId:(nullable NSString *)asMemberId
+             additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders
+                 delegateQueue:(nullable NSOperationQueue *)delegateQueue
+        forceForegroundSession:(BOOL)forceForegroundSession
+     sharedContainerIdentifier:(nullable NSString *)sharedContainerIdentifier {
+    if (self = [super initWithAppKey:appKey
+                           appSecret:appSecret
+                      hostnameConfig:hostnameConfig 
+                         redirectURL:redirectURL
+                           userAgent:userAgent
+                          asMemberId:asMemberId
+                   additionalHeaders:additionalHeaders]) {
+      _delegateQueue = delegateQueue;
+      _forceForegroundSession = forceForegroundSession;
+      _sharedContainerIdentifier = sharedContainerIdentifier;
+    }
   return self;
 }
 

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.h
@@ -90,7 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithAppKey:(NSString *)appKey;
 
 ///
-/// `DBOAuthManager` full constructor.
+/// `DBOAuthManager` convenience constructor.
 ///
 /// @param appKey The app key from the developer console that identifies this app.
 /// @param host The host of the OAuth web flow. Leave nil to use default host.
@@ -98,6 +98,17 @@ NS_ASSUME_NONNULL_BEGIN
 /// @return An initialized instance.
 ///
 - (instancetype)initWithAppKey:(NSString *)appKey host:(nullable NSString *)host;
+
+///
+/// `DBOAuthManager` full constructor.
+///
+/// @param appKey The app key from the developer console that identifies this app.
+/// @param host The host of the OAuth web flow. Leave nil to use default host.
+/// @param redirectURL The redirect url of the OAuth web flow. Default to "db-<appKey>://2/token"
+///
+/// @return An initialized instance.
+///
+- (instancetype)initWithAppKey:(NSString *)appKey host:(nullable NSString *)host redirectURL:(nullable NSString *)redirectURL;
 
 #pragma mark - Auth flow methods
 

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.m
@@ -52,6 +52,10 @@ static DBOAuthManager *s_sharedOAuthManager;
 }
 
 - (instancetype)initWithAppKey:(NSString *)appKey host:(nullable NSString *)host {
+  return [self initWithAppKey:appKey host:host redirectURL:nil];
+}
+
+- (instancetype)initWithAppKey:(NSString *)appKey host:(nullable NSString *)host redirectURL:(nullable NSString *)redirectURL {
   self = [super init];
   if (self) {
     if (host == nil) {
@@ -59,12 +63,16 @@ static DBOAuthManager *s_sharedOAuthManager;
           !kSDKDebug ? @"www.dropbox.com" : [NSString stringWithFormat:@"meta-%@.dev.corp.dropbox.com", kSDKDebugHost];
     }
 
+    if (!redirectURL) {
+      redirectURL = [NSString stringWithFormat:@"db-%@://2/token", _appKey];
+    }
+
     _appKey = appKey;
-    _redirectURL = [[NSURL alloc] initWithString:[NSString stringWithFormat:@"db-%@://2/token", _appKey]];
+    _redirectURL = [[NSURL alloc] initWithString:redirectURL];
     _cancelURL = [NSURL URLWithString:[NSString stringWithFormat:@"db-%@://2/cancel", _appKey]];
     _host = host;
     _urls = [NSMutableArray arrayWithObjects:_redirectURL, nil];
-#ifdef TARGET_OS_X
+#ifdef TARGET_OS_MAC
     _disableSignup = NO;
 #else
     _disableSignup = YES;

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.m
@@ -72,7 +72,7 @@ static DBOAuthManager *s_sharedOAuthManager;
     _cancelURL = [NSURL URLWithString:[NSString stringWithFormat:@"db-%@://2/cancel", _appKey]];
     _host = host;
     _urls = [NSMutableArray arrayWithObjects:_redirectURL, nil];
-#ifdef TARGET_OS_MAC
+#ifdef TARGET_OS_X
     _disableSignup = NO;
 #else
     _disableSignup = YES;

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.m
@@ -51,11 +51,11 @@ static DBOAuthManager *s_sharedOAuthManager;
   return [self initWithAppKey:appKey host:nil];
 }
 
-- (instancetype)initWithAppKey:(NSString *)appKey host:(nullable NSString *)host {
+- (instancetype)initWithAppKey:(NSString *)appKey host:(NSString *)host {
   return [self initWithAppKey:appKey host:host redirectURL:nil];
 }
 
-- (instancetype)initWithAppKey:(NSString *)appKey host:(nullable NSString *)host redirectURL:(nullable NSString *)redirectURL {
+- (instancetype)initWithAppKey:(NSString *)appKey host:(NSString *)host redirectURL:(NSString *)redirectURL {
   self = [super init];
   if (self) {
     if (host == nil) {


### PR DESCRIPTION
This one is for using custom secure redirect url to skip allow page. I tested on paper iOS to see if we can get auth successfully.