### PR TITLE
Update generate_base_client.py to call Stone with route whitelisting

### DIFF
--- a/generate_base_client.py
+++ b/generate_base_client.py
@@ -56,7 +56,12 @@ _cmdline_parser.add_argument(
     action='store_true',
     help='Sets whether generated code should marked for exclusion from analysis.',
 )
-
+_cmdline_parser.add_argument(
+    '-r',
+    '--route-whitelist-filter',
+    type=str,
+    help='Path to route whitelist filter used by Stone. See stone -r for detailed instructions.',
+)
 
 def main():
     """The entry point for the program."""
@@ -94,8 +99,11 @@ def main():
     if verbose:
         print('Generating Obj-C types')
 
-    types_cmd = (['python', '-m', 'stone.cli', '-a', 'host', '-a', 'style',
-                 '-a', 'auth', 'obj_c_types', dropbox_pkg_path] + specs)
+    stone_cmd_prefix = ['python', '-m', 'stone.cli', '-a', 'host', '-a', 'style', '-a', 'auth']
+    if args.route_whitelist_filter:
+        stone_cmd_prefix += ['-r', args.route_whitelist_filter]
+
+    types_cmd = stone_cmd_prefix + ['obj_c_types', dropbox_pkg_path] + specs
 
     if args.documentation or args.exclude_from_analysis:
         types_cmd += ['--']
@@ -116,21 +124,21 @@ def main():
     if verbose:
         print('Generating Obj-C user and team clients')
     o = subprocess.check_output(
-        (['python', '-m', 'stone.cli', '-a', 'host', '-a', 'style', '-a', 'auth', 'obj_c_client', dropbox_pkg_path] +
+        (stone_cmd_prefix + ['obj_c_client', dropbox_pkg_path] +
          specs + ['--', '-w', 'user', '-m', 'DBUserBaseClient', '-c', 'DBUserBaseClient',
          '-t', 'DBTransportClient', '-y', client_args, '-z', style_to_request]),
         cwd=stone_path)
     if o:
         print('Output:', o)
     o = subprocess.check_output(
-        (['python', '-m', 'stone.cli', '-a', 'host', '-a', 'style', '-a', 'auth', 'obj_c_client', dropbox_pkg_path] +
+        (stone_cmd_prefix + ['obj_c_client', dropbox_pkg_path] +
          specs + ['--', '-w', 'team', '-m', 'DBTeamBaseClient', '-c', 'DBTeamBaseClient',
          '-t', 'DBTransportClient', '-y', client_args, '-z', style_to_request]),
         cwd=stone_path)
     if o:
         print('Output:', o)
     o = subprocess.check_output(
-        (['python', '-m', 'stone.cli', '-a', 'host', '-a', 'style', '-a', 'auth', 'obj_c_client', dropbox_pkg_path] +
+        (stone_cmd_prefix + ['obj_c_client', dropbox_pkg_path] +
          specs + ['--', '-w', 'app', '-m', 'DBAppBaseClient', '-c', 'DBAppBaseClient',
          '-t', 'DBTransportClient', '-y', client_args, '-z', style_to_request]),
         cwd=stone_path)


### PR DESCRIPTION
This diff updates the stone submodule to the latest version with route whitelisting and teaches generate_base_client.py to pass in -r to stone if specified by the user. I reran ./generate_base_client.py (without -r) after the edits.