### PR TITLE
Fix format_files.sh to run with bash.

### DIFF
--- a/Format/format_files.sh
+++ b/Format/format_files.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-# e.g. `sh reformat_files.sh <srcs_path>`
+#!/bin/bash
+# e.g. `format_files.sh <srcs_path>`
 #
 
 srcs_path=$1

--- a/generate_base_client.py
+++ b/generate_base_client.py
@@ -148,7 +148,7 @@ def main():
     if verbose:
         print('Formatting source files')
 
-    cmd = ['sh', 'format_files.sh', dropbox_format_output_path]
+    cmd = ['format_files.sh', dropbox_format_output_path]
     o = subprocess.check_output(cmd, cwd=dropbox_format_script_path)
     if o:
         print('Output:', o)


### PR DESCRIPTION
format_files.sh uses bash-specific features (namely [[ ]]), so it use explicitly ask for bash not a generic unix shell.