### PR TITLE
generate_base_client.py: use sys.executable

### DIFF
--- a/generate_base_client.py
+++ b/generate_base_client.py
@@ -99,7 +99,13 @@ def main():
     if verbose:
         print('Generating Obj-C types')
 
-    stone_cmd_prefix = ['python', '-m', 'stone.cli', '-a', 'host', '-a', 'style', '-a', 'auth']
+    stone_cmd_prefix = [
+        sys.executable,
+        '-m', 'stone.cli',
+        '-a', 'host',
+        '-a', 'style',
+        '-a', 'auth',
+    ]
     if args.route_whitelist_filter:
         stone_cmd_prefix += ['-r', args.route_whitelist_filter]
 


### PR DESCRIPTION
This way, if you run generate_base_client.py with a "special" (i.e., non-system) python, that python is also used for subprocesses.