### PR TITLE
Allow configuration of DBOAuthManager to force reauthentication when doing webview auth

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.h
@@ -202,6 +202,16 @@ NS_ASSUME_NONNULL_BEGIN
 /// apps.
 @property (nonatomic, assign) BOOL disableSignup;
 
+///
+/// When YES, users who use the web auth flow (NOT dbapp delegated auth) will be forced to sign in from scratch.
+/// When NO, there is saved session data from the SafariViewController that can be used across signin attempts.
+/// This is intended for use with multi-account applications for App Store compliance, since
+/// adding a second account would shortcut the username/password entry page and use the first account's credentials.
+///
+/// Default value is NO, which is consistent with historical behavior.
+///
+@property (nonatomic, assign) BOOL webAuthShouldForceReauthentication;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.m
@@ -73,6 +73,7 @@ static DBOAuthManager *s_sharedOAuthManager;
 #else
     _disableSignup = YES;
 #endif
+    _webAuthShouldForceReauthentication = NO;
   }
   return self;
 }
@@ -179,6 +180,7 @@ static DBOAuthManager *s_sharedOAuthManager;
     [NSURLQueryItem queryItemWithName:@"client_id" value:_appKey],
     [NSURLQueryItem queryItemWithName:@"redirect_uri" value:[_redirectURL absoluteString]],
     [NSURLQueryItem queryItemWithName:@"disable_signup" value:self.disableSignup ? @"true" : @"false"],
+    [NSURLQueryItem queryItemWithName:@"force_reauthentication" value:self.webAuthShouldForceReauthentication ? @"true" : @"false"],
     [NSURLQueryItem queryItemWithName:@"locale" value:[self.locale localeIdentifier] ?: localeIdentifier],
     [NSURLQueryItem queryItemWithName:@"state" value:state],
   ];


### PR DESCRIPTION
Allows applications with multi-account flows to comply with App Store guidelines (otherwise, would bypass the user/pass entry for the second account, which is confusing)