### PR TITLE
Read downloaded error from NSURL rather than path string

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasks.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasks.m
@@ -328,7 +328,7 @@
 
     if (clientError || !resultData || !location) {
       // error data is in response body (downloaded to output tmp file)
-      NSData *errorData = location ? [NSData dataWithContentsOfFile:[location path]] : nil;
+      NSData *errorData = location ? [NSData dataWithContentsOfURL:location] : nil;
       networkError = [DBTransportBaseClient dBRequestErrorWithErrorData:errorData
                                                             clientError:clientError
                                                              statusCode:statusCode


### PR DESCRIPTION
This allows the URL to point to things other than files, e.g. data:// URLs.