### PR TITLE
Prevent UI thread from blocking during batch upload

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Resources/DBCustomDatatypes.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Resources/DBCustomDatatypes.h
@@ -25,6 +25,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// The queue on which most response handling is performed.
 @property (nonatomic, readonly) NSOperationQueue *queue;
 
+/// The queue on which we sleep until all processing is completed or the timeout is hit.
+@property (nonatomic, readonly) NSOperationQueue *pollingQueue;
+
 /// The dispatch group that pairs upload requests with upload responses so that we can wait for all request/response
 /// pairs to complete before batch committing. In this way, we can start many upload requests (for files under the chunk
 /// limit), without waiting for the corresponding response.

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Resources/DBCustomDatatypes.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Resources/DBCustomDatatypes.m
@@ -16,6 +16,10 @@
     // we specifiy a custom queue so that the main thread is not blocked
     _queue = queue;
     [_queue setMaxConcurrentOperationCount:1];
+      
+    // create a special background queue to monitor progress and sleep until the processing is complete
+    _pollingQueue = [NSOperationQueue new];
+    [_pollingQueue setMaxConcurrentOperationCount:1];
 
     // we want to make sure all of our file data has been uploaded
     // before we make our final batch commit call to `/upload_session/finish_batch`,

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Resources/DBCustomRoutes.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Resources/DBCustomRoutes.m
@@ -381,7 +381,7 @@ static const int timeoutInSec = 200;
             uploadData.responseBlock(nil, routeError, error, uploadData.fileUrlsToRequestErrors);
           }];
         }
-      }];
+      } queue:uploadData.pollingQueue];
 }
 
 - (NSUInteger)endBytesWithFileSize:(NSUInteger)fileSize startBytes:(NSUInteger)startBytes {
@@ -423,7 +423,7 @@ static const int timeoutInSec = 200;
               uploadData.responseBlock(nil, nil, error, uploadData.fileUrlsToRequestErrors);
             }];
           }
-        }];
+        } queue:uploadData.pollingQueue];
   });
 }
 


### PR DESCRIPTION
The `batchUploadFiles` call does not report back a response until all uploads are completed. To do this, it calls `sleep(1)` while it waits for:

1. everything to finish,
2. a cancel request, or
3. all uploads to finish.

The calls to `sleep(1)` are made inside a `setResponseBlock` handler that is not passed a `queue` parameter. Because the queue isn't specified, it runs on the main thread. This causes apps that call this function to freeze on their main thread for a second.

This patch makes a dedicated `NSOperationQueue` for monitoring the progress.