### PR TITLE
Added support to show loading status for the last step of OAuth code …

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Headers/Internal/DBOAuthMobile+Protected.h
+++ b/Source/ObjectiveDropboxOfficial/Headers/Internal/DBOAuthMobile+Protected.h
@@ -1,0 +1,16 @@
+///
+/// Copyright (c) 2020 Dropbox, Inc. All rights reserved.
+///
+
+#import "DBLoadingStatusDelegate.h"
+#import "DBOAuthMobile-iOS.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface DBMobileSharedApplication (Protected)
+
+@property (nonatomic, readwrite, weak) id<DBLoadingStatusDelegate> loadingStatusDelegate;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/ObjectiveDropboxOfficial/Headers/Internal/OAuth/DBLoadingViewController.h
+++ b/Source/ObjectiveDropboxOfficial/Headers/Internal/OAuth/DBLoadingViewController.h
@@ -1,0 +1,19 @@
+///
+/// Copyright (c) 2020 Dropbox, Inc. All rights reserved.
+///
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface DBLoadingViewController : UIViewController
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
+
+- (instancetype)initWithNibName:(nullable NSString *)nibNameOrNil
+                         bundle:(nullable NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/ObjectiveDropboxOfficial/ObjectiveDropboxOfficial.xcodeproj/project.pbxproj
+++ b/Source/ObjectiveDropboxOfficial/ObjectiveDropboxOfficial.xcodeproj/project.pbxproj
@@ -40,6 +40,10 @@
 		BF474D39248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = BF474D36248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.h */; };
 		BF474D3A248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = BF474D37248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.m */; };
 		BF474D3B248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = BF474D37248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.m */; };
+		BF7E352B2488562F00DEDF84 /* DBLoadingViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = BF7E35292488562F00DEDF84 /* DBLoadingViewController.h */; };
+		BF7E352C2488562F00DEDF84 /* DBLoadingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BF7E352A2488562F00DEDF84 /* DBLoadingViewController.m */; };
+		BF7E352E248858B600DEDF84 /* DBLoadingStatusDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = BF7E352D248858B600DEDF84 /* DBLoadingStatusDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BF7E353024885A9A00DEDF84 /* DBOAuthMobile+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = BF7E352F24885A9A00DEDF84 /* DBOAuthMobile+Protected.h */; };
 		C43D4E69245748BB008DF48C /* DBStoneBase.m in Sources */ = {isa = PBXBuildFile; fileRef = C43D46EE245748AF008DF48C /* DBStoneBase.m */; };
 		C43D4E6A245748BB008DF48C /* DBStoneBase.m in Sources */ = {isa = PBXBuildFile; fileRef = C43D46EE245748AF008DF48C /* DBStoneBase.m */; };
 		C43D4E6B245748BB008DF48C /* DBStoneSerializers.m in Sources */ = {isa = PBXBuildFile; fileRef = C43D46EF245748AF008DF48C /* DBStoneSerializers.m */; };
@@ -3944,6 +3948,10 @@
 		BF33F93D24874DED001F4072 /* DBOAuthTokenRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DBOAuthTokenRequest.m; sourceTree = "<group>"; };
 		BF474D36248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DBAccessToken+NSSecureCoding.h"; sourceTree = "<group>"; };
 		BF474D37248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "DBAccessToken+NSSecureCoding.m"; sourceTree = "<group>"; };
+		BF7E35292488562F00DEDF84 /* DBLoadingViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DBLoadingViewController.h; sourceTree = "<group>"; };
+		BF7E352A2488562F00DEDF84 /* DBLoadingViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DBLoadingViewController.m; sourceTree = "<group>"; };
+		BF7E352D248858B600DEDF84 /* DBLoadingStatusDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DBLoadingStatusDelegate.h; sourceTree = "<group>"; };
+		BF7E352F24885A9A00DEDF84 /* DBOAuthMobile+Protected.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DBOAuthMobile+Protected.h"; sourceTree = "<group>"; };
 		C43D46EE245748AF008DF48C /* DBStoneBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DBStoneBase.m; sourceTree = "<group>"; };
 		C43D46EF245748AF008DF48C /* DBStoneSerializers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DBStoneSerializers.m; sourceTree = "<group>"; };
 		C43D46F0245748AF008DF48C /* DBStoneValidators.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DBStoneValidators.m; sourceTree = "<group>"; };
@@ -8181,6 +8189,7 @@
 		F235B51A1E29913600144F8B /* ObjectiveDropboxOfficial_iOS */ = {
 			isa = PBXGroup;
 			children = (
+				BF7E352D248858B600DEDF84 /* DBLoadingStatusDelegate.h */,
 				F235B51F1E29913600144F8B /* DBSDKImports-iOS.h */,
 				F235B51D1E29913600144F8B /* DBClientsManager+MobileAuth-iOS.h */,
 				F235B51E1E29913600144F8B /* DBClientsManager+MobileAuth-iOS.m */,
@@ -8190,6 +8199,7 @@
 				F2C59AF91E9C2CAF00E8D2E6 /* DBOAuthMobileManager-iOS.m */,
 				F235B5201E29913600144F8B /* Info.plist */,
 				F2A2DBA71E578C3E001D8449 /* OfficialPartners */,
+				BF7E352A2488562F00DEDF84 /* DBLoadingViewController.m */,
 			);
 			name = ObjectiveDropboxOfficial_iOS;
 			path = Platform/ObjectiveDropboxOfficial_iOS;
@@ -8353,6 +8363,7 @@
 		F2A2CE741E562817001D8449 /* Internal */ = {
 			isa = PBXGroup;
 			children = (
+				BF7E352F24885A9A00DEDF84 /* DBOAuthMobile+Protected.h */,
 				F2A2CE751E562817001D8449 /* DBClientsManager+Protected.h */,
 				F2A2CE761E562817001D8449 /* Networking */,
 				F2C59AFB1E9C2EEC00E8D2E6 /* OAuth */,
@@ -8417,6 +8428,7 @@
 			isa = PBXGroup;
 			children = (
 				BF474D36248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.h */,
+				BF7E35292488562F00DEDF84 /* DBLoadingViewController.h */,
 				BF33F93B24874DED001F4072 /* DBOAuthTokenRequest.h */,
 				BF33F92424873F11001F4072 /* DBOAuthConstants.h */,
 				BF33F92324873F11001F4072 /* DBOAuthPKCESession.h */,
@@ -8633,6 +8645,7 @@
 				C43D5917245748D0008DF48C /* DBTEAMLOGUserNameLogInfo.h in Headers */,
 				C43D5BF7245748D7008DF48C /* DBFILESDownloadZipError.h in Headers */,
 				C43D56DB245748CC008DF48C /* DBTEAMLOGFileUnlikeCommentType.h in Headers */,
+				BF7E352E248858B600DEDF84 /* DBLoadingStatusDelegate.h in Headers */,
 				C43D5C11245748D7008DF48C /* DBFILESDownloadArg.h in Headers */,
 				C43D56C1245748CC008DF48C /* DBTEAMLOGFileGetCopyReferenceType.h in Headers */,
 				C43D58C5245748D0008DF48C /* DBTEAMLOGTeamProfileChangeLogoDetails.h in Headers */,
@@ -9071,6 +9084,7 @@
 				C43D533D245748C4008DF48C /* DBUSERSName.h in Headers */,
 				C43D4E97245748BB008DF48C /* DBPAPERCursor.h in Headers */,
 				C43D59FB245748D2008DF48C /* DBTEAMLOGMemberChangeMembershipTypeDetails.h in Headers */,
+				BF7E352B2488562F00DEDF84 /* DBLoadingViewController.h in Headers */,
 				C43D5453245748C7008DF48C /* DBTEAMLOGEmmCreateExceptionsReportDetails.h in Headers */,
 				C43D5659245748CB008DF48C /* DBTEAMLOGFilePreviewType.h in Headers */,
 				C43D5A39245748D3008DF48C /* DBTEAMLOGTrustedNonTeamMemberType.h in Headers */,
@@ -9520,6 +9534,7 @@
 				C43D5177245748C1008DF48C /* DBTEAMMembersSetProfileError.h in Headers */,
 				C43D5C51245748D8008DF48C /* DBFILESUploadSessionFinishBatchArg.h in Headers */,
 				C43D56A7245748CB008DF48C /* DBTEAMLOGTfaConfiguration.h in Headers */,
+				BF7E353024885A9A00DEDF84 /* DBOAuthMobile+Protected.h in Headers */,
 				C43D52E5245748C4008DF48C /* DBFILEPROPERTIESPropertiesSearchMode.h in Headers */,
 				C43D5873245748CF008DF48C /* DBTEAMLOGMemberSetProfilePhotoDetails.h in Headers */,
 				C43D55AB245748C9008DF48C /* DBTEAMLOGSharedLinkChangeExpiryDetails.h in Headers */,
@@ -12353,6 +12368,7 @@
 				C43D5C8D245748D8008DF48C /* DBUserBaseClient.m in Sources */,
 				F29789111E03692F00876A73 /* DBCustomRoutes.m in Sources */,
 				F29788CF1E03692F00876A73 /* DBTeamClient.m in Sources */,
+				BF7E352C2488562F00DEDF84 /* DBLoadingViewController.m in Sources */,
 				F241694F1E5247DB0038E306 /* DBTransportBaseConfig.m in Sources */,
 				C43D5CBF245748D9008DF48C /* DBFILESAppAuthRoutes.m in Sources */,
 				F2A2DBB01E578C3F001D8449 /* DBOpenWithInfo-iOS.m in Sources */,

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBClientsManager+MobileAuth-iOS.h
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBClientsManager+MobileAuth-iOS.h
@@ -11,6 +11,8 @@
 @class UIApplication;
 @class UIViewController;
 
+@protocol DBLoadingStatusDelegate;
+
 NS_ASSUME_NONNULL_BEGIN
 
 ///
@@ -47,11 +49,15 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param sharedApplication The `UIApplication` with which to render the OAuth flow.
 /// @param controller The `UIViewController` with which to render the OAuth flow. Please ensure that this is the
 /// top-most view controller, so that the authorization view displays correctly.
+/// @param loadingStatusDelegate An optional delegate to handle loading experience during auth flow.
+/// e.g. Show a looading spinner and block user interaction while loading/waiting.
+/// If a delegate is not provided, the SDK will show a default loading spinner when necessary.
 /// @param openURL A wrapper around app-extension unsafe `openURL` call.
 /// @param scopeRequest Request contains information of scopes to be obtained.
 ///
 + (void)authorizeFromControllerV2:(UIApplication *)sharedApplication
                        controller:(nullable UIViewController *)controller
+            loadingStatusDelegate:(nullable id<DBLoadingStatusDelegate>)loadingStatusDelegate
                           openURL:(void (^_Nonnull)(NSURL *))openURL
                      scopeRequest:(nullable DBScopeRequest*)scopeRequest;
 

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBClientsManager+MobileAuth-iOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBClientsManager+MobileAuth-iOS.m
@@ -6,9 +6,11 @@
 
 #import "DBClientsManager+Protected.h"
 #import "DBClientsManager.h"
+#import "DBLoadingStatusDelegate.h"
 #import "DBOAuthManager.h"
 #import "DBOAuthMobile-iOS.h"
 #import "DBOAuthMobileManager-iOS.h"
+#import "DBOAuthMobile+Protected.h"
 #import "DBScopeRequest.h"
 #import "DBTransportDefaultConfig.h"
 
@@ -29,6 +31,7 @@
 
 + (void)authorizeFromControllerV2:(UIApplication *)sharedApplication
                        controller:(nullable UIViewController *)controller
+            loadingStatusDelegate:(nullable id<DBLoadingStatusDelegate>)loadingStatusDelegate
                           openURL:(void (^_Nonnull)(NSURL *))openURL
                      scopeRequest:(nullable DBScopeRequest*)scopeRequest {
   NSAssert([DBOAuthManager sharedOAuthManager] != nil,
@@ -37,6 +40,7 @@
   [[DBMobileSharedApplication alloc] initWithSharedApplication:sharedApplication
                                                     controller:controller
                                                        openURL:openURL];
+  sharedMobileApplication.loadingStatusDelegate = loadingStatusDelegate;
   [DBMobileSharedApplication setMobileSharedApplication:sharedMobileApplication];
   [[DBOAuthManager sharedOAuthManager] authorizeFromSharedApplication:sharedMobileApplication
                                                               usePkce:YES

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBLoadingStatusDelegate.h
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBLoadingStatusDelegate.h
@@ -1,0 +1,21 @@
+///
+/// Copyright (c) 2020 Dropbox, Inc. All rights reserved.
+///
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Protocol for handling loading status during auth flow.
+/// Implementing class could show custom UX to reflect loading status.
+@protocol DBLoadingStatusDelegate <NSObject>
+
+/// Called when auth flow is loading/waiting for some data. e.g. Waiting for a network request to finish.
+- (void)showLoading;
+
+/// Called when auth flow finishes loading/waiting. e.g. A network request finished.
+- (void)dismissLoading;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBLoadingViewController.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBLoadingViewController.m
@@ -1,0 +1,41 @@
+///
+/// Copyright (c) 2020 Dropbox, Inc. All rights reserved.
+///
+
+#import "DBLoadingViewController.h"
+
+@interface DBLoadingViewController ()
+
+@property (nonatomic, readwrite, strong) UIActivityIndicatorView *loadingSpinner;
+
+@end
+
+@implementation DBLoadingViewController
+
+- (instancetype)init {
+  self = [super initWithNibName:nil bundle:nil];
+  if (self) {
+    if (@available(iOS 13.0, *)) {
+      _loadingSpinner =
+        [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleLarge];
+    } else {
+      _loadingSpinner =
+        [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
+    }
+  }
+  return self;
+}
+
+- (void)viewDidLoad {
+  UIView *view = self.view;
+  view.backgroundColor = [UIColor.blackColor colorWithAlphaComponent:0.4];
+  [view addSubview:_loadingSpinner];
+  _loadingSpinner.translatesAutoresizingMaskIntoConstraints = NO;
+  [NSLayoutConstraint activateConstraints:@[
+    [_loadingSpinner.centerXAnchor constraintEqualToAnchor:view.centerXAnchor],
+    [_loadingSpinner.centerYAnchor constraintEqualToAnchor:view.centerYAnchor],
+  ]];
+  [_loadingSpinner startAnimating];
+}
+
+@end

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobile-iOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobile-iOS.m
@@ -3,12 +3,21 @@
 ///
 
 #import "DBOAuthMobile-iOS.h"
+
+#import "DBLoadingStatusDelegate.h"
+#import "DBLoadingViewController.h"
 #import "DBOAuthManager.h"
 #import "DBSDKSystem.h"
 
 #pragma mark - Shared application
 
 static DBMobileSharedApplication *s_mobileSharedApplication;
+
+@interface DBMobileSharedApplication ()
+
+@property (nonatomic, readwrite, weak) id<DBLoadingStatusDelegate> loadingStatusDelegate;
+
+@end
 
 @implementation DBMobileSharedApplication {
   UIApplication *_sharedApplication;
@@ -116,6 +125,74 @@ static DBMobileSharedApplication *s_mobileSharedApplication;
       [_controller dismissViewControllerAnimated:YES completion:nil];
     }
     _controller = nil;
+  }
+}
+
+- (void)presentLoading {
+  if ([self db_isWebOAuthFlow]) {
+    [self db_presentLoadingInWeb];
+  } else {
+    [self db_presentLoadingInApp];
+  }
+}
+
+- (void)dismissLoading {
+  if ([self db_isWebOAuthFlow]) {
+    [self db_dismissLoadingInWeb];
+  } else {
+    [self db_dismissLoadingInApp];
+  }
+}
+
+#pragma mark Private helpers
+
+- (BOOL)db_isWebOAuthFlow {
+  return [_controller.presentedViewController isKindOfClass:[DBMobileSafariViewController class]];
+}
+
+// Web OAuth flow, present the spinner over the MobileSafariViewController.
+- (void)db_presentLoadingInWeb {
+  UIViewController *vc = _controller.presentedViewController;
+  if ([vc isKindOfClass:[DBMobileSafariViewController class]]) {
+    [self db_presentLoadingInViewController:vc];
+  }
+}
+
+- (void)db_dismissLoadingInWeb {
+  UIViewController *vc = _controller.presentedViewController;
+  if ([vc isKindOfClass:[DBMobileSafariViewController class]]) {
+    [self db_dismissLoadingInViewController:vc];
+  }
+}
+
+// Delegate to app to present loading if delegate is set. Otherwise, present the spinner in the view controller.
+- (void)db_presentLoadingInApp {
+  if (_loadingStatusDelegate) {
+    [_loadingStatusDelegate showLoading];
+  } else {
+    [self db_presentLoadingInViewController:_controller];
+  }
+}
+
+// Delegate to app to dismiss loading if delegate is set. Otherwise, dismiss the spinner in the view controller.
+- (void)db_dismissLoadingInApp {
+  if (_loadingStatusDelegate) {
+    [_loadingStatusDelegate dismissLoading];
+  } else {
+    [self db_dismissLoadingInViewController:_controller];
+  }
+}
+
+- (void)db_presentLoadingInViewController:(UIViewController *)viewController {
+  DBLoadingViewController *loadingVC = [[DBLoadingViewController alloc] init];
+  loadingVC.modalPresentationStyle = UIModalPresentationOverFullScreen;
+  [viewController presentViewController:loadingVC animated:false completion:nil];
+}
+
+- (void)db_dismissLoadingInViewController:(UIViewController *)viewController {
+  UIViewController *presentedVC = _controller.presentedViewController;
+  if ([presentedVC isKindOfClass:[DBLoadingViewController class]]) {
+    [presentedVC dismissViewControllerAnimated:false completion:nil];
   }
 }
 

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobileManager-iOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobileManager-iOS.m
@@ -4,6 +4,7 @@
 
 #import "DBOAuthMobileManager-iOS.h"
 
+#import "DBLoadingViewController.h"
 #import "DBOAuthConstants.h"
 #import "DBOAuthManager+Protected.h"
 #import "DBOAuthMobile-iOS.h"

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBSDKImports-iOS.h
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBSDKImports-iOS.h
@@ -3,6 +3,7 @@
 ///
 
 #import "DBClientsManager+MobileAuth-iOS.h"
+#import "DBLoadingStatusDelegate.h"
 #import "DBOAuthMobile-iOS.h"
 #import "DBOAuthMobileManager-iOS.h"
 

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBOAuthDesktop-macOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBOAuthDesktop-macOS.m
@@ -61,4 +61,12 @@
   return YES;
 }
 
+- (void)presentLoading {
+  // TODO: Implement when OAuth code flow is introduced to Desktop SDK.
+}
+
+- (void)dismissLoading {
+  // TODO: Implement when OAuth code flow is introduced to Desktop SDK.
+}
+
 @end

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBSharedApplicationProtocol.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBSharedApplicationProtocol.h
@@ -71,6 +71,13 @@ typedef void (^DBOAuthCancelBlock)(void);
 ///
 - (BOOL)canPresentExternalApp:(NSURL *)url;
 
+/// Presents platform-specific loading UX indicating an async operation is ongoing and potentially blocking
+/// user interaction while loading.
+- (void)presentLoading;
+
+/// Dismisses loading UX.
+- (void)dismissLoading;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
…flow

OAuth code flow requires a network request to get access token, apps should build some UX to handle this async operation.
A default UX is built in the SDK with showing a load spinner while waiting for oauth token request to finish.
Apps can provide a `DBLoadingStatusDelegate` to override the default and show some custom experience.