### PR TITLE
Short-lived token refresh support - part 2

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Headers/Internal/Networking/DBDelegate.h
+++ b/Source/ObjectiveDropboxOfficial/Headers/Internal/Networking/DBDelegate.h
@@ -45,10 +45,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithQueue:(nullable NSOperationQueue *)delegateQueue;
 
 ///
-/// Enqueues a handler to be executed periodically to retrieve information on the progress of the supplied
-/// `NSURLSessionTask` task for the corresponding Upload-style request.
+/// Enqueues a handler to be executed periodically to retrieve information on the progress of the
+/// `NSURLSessionTask` identified by the supplied task identifier for the corresponding Upload-style request.
 ///
-/// @param task The `NSURLSessionTask` task associated with the API request.
+/// @param identifier The identifier of the `NSURLSessionTask` task associated with the API request.
 /// @param session The `NSURLSession` session associated with the API request.
 /// @param handler The progress block to be executed in the event of a request update. The first argument is the number
 /// of bytes downloaded. The second argument is the number of total bytes downloaded. And the third argument is the
@@ -56,61 +56,61 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param handlerQueue The operation queue on which to execute progress handler code. If nil, then the progress queue
 /// is the queue with which the delegate object was instantiated.
 ///
-- (void)addProgressHandler:(NSURLSessionTask *)task
-                   session:(NSURLSession *)session
-           progressHandler:(DBProgressBlock)handler
-      progressHandlerQueue:(nullable NSOperationQueue *)handlerQueue;
+- (void)addProgressHandlerForTaskWithIdentifier:(NSUInteger)identifier
+                                        session:(NSURLSession *)session
+                                progressHandler:(DBProgressBlock)handler
+                           progressHandlerQueue:(nullable NSOperationQueue *)handlerQueue;
 
 #pragma mark - Add RPC-style handlers
 
 ///
-/// Enqueues a handler to be executed upon completion of the supplied `NSURLSessionTask` task for the corresponding
-/// RPC-style request.
+/// Enqueues a handler to be executed upon completion of the `NSURLSessionTask` identified by the supplied
+/// task identifier for the corresponding RPC-style request.
 ///
-/// @param task The `NSURLSessionTask` task associated with the API request.
+/// @param identifier The identifier of the `NSURLSessionTask` task associated with the API request.
 /// @param session The `NSURLSession` session associated with the API request.
 /// @param handler The handler block to be executed in the event of a successful or unsuccessful network request.
 /// @param handlerQueue The operation queue on which to execute response handler code. If nil, then the response queue
 /// is the queue with which the delegate object was instantiated.
 ///
-- (void)addRpcResponseHandler:(NSURLSessionTask *)task
-                      session:(NSURLSession *)session
-              responseHandler:(DBRpcResponseBlockStorage)handler
-         responseHandlerQueue:(nullable NSOperationQueue *)handlerQueue;
+- (void)addRpcResponseHandlerForTaskWithIdentifier:(NSUInteger)identifier
+                                           session:(NSURLSession *)session
+                                   responseHandler:(DBRpcResponseBlockStorage)handler
+                              responseHandlerQueue:(nullable NSOperationQueue *)handlerQueue;
 
 #pragma mark - Add Upload-style handlers
 
 ///
-/// Enqueues a handler to be executed upon completion of the supplied `NSURLSessionTask` task for the corresponding
-/// Upload-style request.
+/// Enqueues a handler to be executed upon completion of the `NSURLSessionTask` task identified by the supplied
+/// task identifier for the corresponding Upload-style request.
 ///
-/// @param task The `NSURLSessionTask` task associated with the API request.
+/// @param identifier The identifier of the `NSURLSessionTask` task associated with the API request.
 /// @param session The `NSURLSession` session associated with the API request.
 /// @param handler The handler block to be executed in the event of a successful or unsuccessful network request.
 /// @param handlerQueue The operation queue on which to execute response handler code. If nil, then the response queue
 /// is the queue with which the delegate object was instantiated.
 ///
-- (void)addUploadResponseHandler:(NSURLSessionTask *)task
-                         session:(NSURLSession *)session
-                 responseHandler:(DBUploadResponseBlockStorage)handler
-            responseHandlerQueue:(nullable NSOperationQueue *)handlerQueue;
+- (void)addUploadResponseHandlerForTaskWithIdentifier:(NSUInteger)identifier
+                                              session:(NSURLSession *)session
+                                      responseHandler:(DBUploadResponseBlockStorage)handler
+                                 responseHandlerQueue:(nullable NSOperationQueue *)handlerQueue;
 
 #pragma mark - Add Download-style handlers
 
 ///
-/// Enqueues a handler to be executed upon completion of the supplied `NSURLSessionTask` task for the corresponding
-/// Download-style request.
+/// Enqueues a handler to be executed upon completion of the `NSURLSessionTask` task identified by the supplied
+/// task identifier for the corresponding Download-style request.
 ///
-/// @param task The `NSURLSessionTask` task associated with the API request.
+/// @param identifier The identifier of the `NSURLSessionTask` task associated with the API request.
 /// @param session The `NSURLSession` session associated with the API request.
 /// @param handler The handler block to be executed in the event of a successful or unsuccessful network request.
 /// @param handlerQueue The operation queue on which to execute response handler code. If nil, then the response queue
 /// is the queue with which the delegate object was instantiated.
 ///
-- (void)addDownloadResponseHandler:(NSURLSessionTask *)task
-                           session:(NSURLSession *)session
-                   responseHandler:(DBDownloadResponseBlockStorage)handler
-              responseHandlerQueue:(nullable NSOperationQueue *)handlerQueue;
+- (void)addDownloadResponseHandlerForTaskWithIdentifier:(NSUInteger)identifier
+                                                session:(NSURLSession *)session
+                                        responseHandler:(DBDownloadResponseBlockStorage)handler
+                                   responseHandlerQueue:(nullable NSOperationQueue *)handlerQueue;
 
 @end
 

--- a/Source/ObjectiveDropboxOfficial/Headers/Internal/Networking/DBTasksImpl.h
+++ b/Source/ObjectiveDropboxOfficial/Headers/Internal/Networking/DBTasksImpl.h
@@ -7,6 +7,7 @@
 #import "DBHandlerTypes.h"
 #import "DBTasks.h"
 #import "DBTasksImpl.h"
+#import "DBURLSessionTaskWithTokenRefresh.h"
 
 @class DBBatchUploadData;
 @class DBDelegate;
@@ -19,32 +20,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface DBRpcTaskImpl : DBRpcTask
 
-/// The `NSURLSessionTask` that was used to make the request.
-@property (nonatomic, readonly) NSURLSessionDataTask *dataTask;
-
-/// The session that was used to make to the request.
-@property (nonatomic, readonly) NSURLSession *session;
-
-/// The delegate used manage handler code.
-@property (nonatomic, readonly) DBDelegate *delegate;
-
 ///
 /// `DBRpcTaskImpl` full constructor.
 ///
-/// @param task The `NSURLSessionDataTask` task that initialized the network request.
+/// @param task The `DBURLSessionTask` task that initialized the network request.
 /// @param tokenUid Identifies a unique Dropbox account. Used for the multi Dropbox account case where client objects
 /// are each associated with a particular Dropbox account.
-/// @param session The `NSURLSession` used to make the network request.
-/// @param delegate The delegate that manages and executes response code.
 /// @param route The static `DBRoute` instance associated with the route to which the request was made. Contains
 /// information like route host, response type, etc.). This is used in the deserialization process.
 ///
 /// @return An initialized instance.
 ///
-- (instancetype)initWithTask:(NSURLSessionDataTask *)task
+- (instancetype)initWithTask:(id<DBURLSessionTask>)task
                     tokenUid:(nullable NSString *)tokenUid
-                     session:(NSURLSession *)session
-                    delegate:(DBDelegate *)delegate
                        route:(DBRoute *)route;
 @end
 
@@ -52,57 +40,31 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface DBUploadTaskImpl : DBUploadTask
 
-/// The `NSURLSessionTask` that was used to make the request.
-@property (nonatomic, readonly) NSURLSessionUploadTask *uploadTask;
-
 /// The session that was used to make to the request.
 @property (nonatomic, readonly) NSURLSession *session;
-
-/// The delegate used manage handler code.
-@property (nonatomic, readonly) DBDelegate *delegate;
-
-/// The url to upload.
-@property (nonatomic, readonly, nullable) NSURL *inputUrl;
-
-/// The data to upload.
-@property (nonatomic, readonly, nullable) NSData *inputData;
 
 ///
 /// `DBUploadTask` full constructor.
 ///
-/// @param task The `NSURLSessionDataTask` task that initialized the network request.
+/// @param task The `DBURLSessionTask` task that initialized the network request.
 /// @param tokenUid Identifies a unique Dropbox account. Used for the multi Dropbox account case where client objects
 /// are each associated with a particular Dropbox account.
-/// @param session The `NSURLSession` used to make the network request.
-/// @param delegate The delegate that manages and executes response code.
 /// @param route The static `DBRoute` instance associated with the route to which the request was made. Contains
 /// information like route host, response type, etc.). This is used in the deserialization process.
-/// @param inputUrl The url to upload.
-/// @param inputData The data to upload.
 ///
 /// @return An initialized instance.
 ///
-- (instancetype)initWithTask:(NSURLSessionUploadTask *)task
+- (instancetype)initWithTask:(id<DBURLSessionTask>)task
                     tokenUid:(nullable NSString *)tokenUid
-                     session:(NSURLSession *)session
-                    delegate:(DBDelegate *)delegate
-                       route:(DBRoute *)route
-                    inputUrl:(nullable NSURL *)inputUrl
-                   inputData:(nullable NSData *)inputData;
+                       route:(DBRoute *)route;
 @end
 
 #pragma mark - Download-style network task (NSURL)
 
 @interface DBDownloadUrlTaskImpl : DBDownloadUrlTask
 
-/// The `NSURLSessionTask` that was used to make the request.
-@property (nonatomic, readonly) NSURLSessionDownloadTask *downloadUrlTask;
-
 /// The session that was used to make to the request.
 @property (nonatomic, readonly) NSURLSession *session;
-
-/// The delegate used manage handler code.
-@property (nonatomic, readonly) DBDelegate *delegate;
 
 ///
 /// `DBDownloadUrlTask` full constructor.
@@ -110,8 +72,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param task The `NSURLSessionDataTask` task that initialized the network request.
 /// @param tokenUid Identifies a unique Dropbox account. Used for the multi Dropbox account case where client objects
 /// are each associated with a particular Dropbox account.
-/// @param session The `NSURLSession` used to make the network request.
-/// @param delegate The delegate that manages and executes response code.
 /// @param route The static `DBRoute` instance associated with the route to which the request was made. Contains
 /// information like route host, response type, etc.). This is used in the deserialization process.
 /// @param overwrite Whether the outputted file should overwrite in the event of a name collision.
@@ -119,10 +79,8 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// @return An initialized instance.
 ///
-- (instancetype)initWithTask:(NSURLSessionDownloadTask *)task
+- (instancetype)initWithTask:(id<DBURLSessionTask>)task
                     tokenUid:(nullable NSString *)tokenUid
-                     session:(NSURLSession *)session
-                    delegate:(DBDelegate *)delegate
                        route:(DBRoute *)route
                    overwrite:(BOOL)overwrite
                  destination:(NSURL *)destination;
@@ -132,14 +90,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface DBDownloadDataTaskImpl : DBDownloadDataTask
 
-/// The `NSURLSessionTask` that was used to make the request.
-@property (nonatomic, readonly) NSURLSessionDownloadTask *downloadDataTask;
-
 /// The session that was used to make to the request.
 @property (nonatomic, readonly) NSURLSession *session;
-
-/// The delegate used manage handler code.
-@property (nonatomic, readonly) DBDelegate *delegate;
 
 ///
 /// DBDownloadDataTask full constructor.
@@ -147,17 +99,13 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param task The `NSURLSessionDataTask` task that initialized the network request.
 /// @param tokenUid Identifies a unique Dropbox account. Used for the multi Dropbox account case where client objects
 /// are each associated with a particular Dropbox account.
-/// @param session The `NSURLSession` used to make the network request.
-/// @param delegate The delegate that manages and executes response code.
 /// @param route The static `DBRoute` instance associated with the route to which the request was made. Contains
 /// information like route host, response type, etc.). This is used in the deserialization process.
 ///
 /// @return An initialized instance.
 ///
-- (instancetype)initWithTask:(NSURLSessionDownloadTask *)task
+- (instancetype)initWithTask:(id<DBURLSessionTask>)task
                     tokenUid:(nullable NSString *)tokenUid
-                     session:(NSURLSession *)session
-                    delegate:(DBDelegate *)delegate
                        route:(DBRoute *)route;
 @end
 

--- a/Source/ObjectiveDropboxOfficial/Headers/Internal/Networking/DBURLSessionTaskWithTokenRefresh.h
+++ b/Source/ObjectiveDropboxOfficial/Headers/Internal/Networking/DBURLSessionTaskWithTokenRefresh.h
@@ -1,0 +1,84 @@
+///
+/// Copyright (c) 2020 Dropbox, Inc. All rights reserved.
+///
+
+#import <Foundation/Foundation.h>
+#import "DBHandlerTypes.h"
+#import "DBHandlerTypesInternal.h"
+#import "DBTasks.h"
+
+@protocol DBAccessTokenProvider;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Response handler for DBURLSessionTask.
+@interface DBURLSessionTaskResponseBlockWrapper: NSObject
+
+/// Handler wrapper for RPC tasks.
++ (DBURLSessionTaskResponseBlockWrapper *)withRpcResponseBlock:(DBRpcResponseBlockStorage)responseBlock;
+/// Handler wrapper for upload tasks.
++ (DBURLSessionTaskResponseBlockWrapper *)withUploadResponseBlock:(DBUploadResponseBlockStorage)responseBlock;
+/// Handler wrapper for download tasks.
++ (DBURLSessionTaskResponseBlockWrapper *)withDownloadResponseBlock:(DBDownloadResponseBlockStorage)responseBlock;
+
+@end
+
+/// Protocol for custom URLSession tasks that are used internally by the DBTask classes.
+@protocol DBURLSessionTask <NSObject>
+
+typedef void (^DBURLSessionTaskSetupBlock)(NSUInteger taskIdentifier);
+
+/// The `NSURLSession` used to make the network request.
+@property (nonatomic, readonly) NSURLSession *session;
+
+/// Creates a new instance with same initial setup.
+- (id<DBURLSessionTask>)duplicate;
+
+/// Cancels the API request.
+- (void)cancel;
+
+/// Suspends the API request.
+- (void)suspend;
+
+/// Resumes the API request.
+- (void)resume;
+
+/// Sets progress handler for the task.
+/// @param progressBlock The `DBProgressBlock` that handles task progress.
+/// @param queue An optional operation queue on which to execute progress handler code. If not provided, the handler
+/// may be executed on any queue.
+- (void)setProgressBlock:(DBProgressBlock)progressBlock queue:(nullable NSOperationQueue *)queue;
+
+/// Sets response/completion handler for the task.
+/// @param responseBlock The `DBURLSessionTaskResponseBlock` that handles task response.
+/// @param queue An optional operation queue on which to execute response handler code. If not provided, the handler
+/// may be executed on any queue.
+- (void)setResponseBlock:(DBURLSessionTaskResponseBlockWrapper *)responseBlock
+                   queue:(nullable NSOperationQueue *)queue;
+
+@end
+
+/// Block that creates the actual API request.
+typedef NSURLSessionTask *_Nonnull(^DBURLSessionTaskCreationBlock)(void);
+
+/// A class that wraps a network request that calls Dropbox API.
+/// This class will first attempt to refresh the access token and conditionally proceed to the actual API call.
+@interface DBURLSessionTaskWithTokenRefresh : NSObject<DBURLSessionTask>
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/// Designated Initializer.
+///
+/// @param taskCreationBlock The block that creates the actual API request.
+/// @param taskDelegate The delegate used manage request handler code.
+/// @param urlSession The `NSURLSession` used to make the API network request.
+/// @param tokenProvider The `DBAccessTokenProvider` object to perform token refresh.
+///
+- (instancetype)initWithTaskCreationBlock:(DBURLSessionTaskCreationBlock)taskCreationBlock
+                             taskDelegate:(nullable DBDelegate *)taskDelegate
+                               urlSession:(NSURLSession *)urlSession
+                            tokenProvider:(id<DBAccessTokenProvider>)tokenProvider NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/ObjectiveDropboxOfficial/Headers/Internal/OAuth/DBAccessTokenProvider+Internal.h
+++ b/Source/ObjectiveDropboxOfficial/Headers/Internal/OAuth/DBAccessTokenProvider+Internal.h
@@ -1,0 +1,36 @@
+///
+/// Copyright (c) 2020 Dropbox, Inc. All rights reserved.
+///
+
+#import "DBAccessTokenProvider.h"
+#import "DBOAuthManager.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Wrapper for legacy long-lived access token.
+@interface DBLongLivedAccessTokenProvider: NSObject<DBAccessTokenProvider>
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/// Designated initializer.
+///
+/// @param tokenString An access token string.
+- (instancetype)initWithTokenString:(NSString *)tokenString NS_DESIGNATED_INITIALIZER;
+
+@end
+
+/// Wrapper for short-lived token.
+@interface DBShortLivedAccessTokenProvider: NSObject<DBAccessTokenProvider>
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/// Designated initializer.
+///
+/// @param token A `DBAccessToken` represents a short-lived token.
+/// @param tokenRefresher Helper object that refreshes a token over network.
+- (instancetype)initWithToken:(DBAccessToken *)token
+               tokenRefresher:(id<DBAccessTokenRefreshing>)tokenRefresher NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/ObjectiveDropboxOfficial/Headers/Internal/OAuth/DBOAuthManager+Protected.h
+++ b/Source/ObjectiveDropboxOfficial/Headers/Internal/OAuth/DBOAuthManager+Protected.h
@@ -7,6 +7,8 @@
 #import "DBOAuthManager.h"
 #import "DBOAuthResultCompletion.h"
 
+@protocol DBAccessTokenProvider;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface DBOAuthManager (Protected)
@@ -22,6 +24,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)finishPkceOAuthWithAuthCode:(NSString *)authCode
                        codeVerifier:(NSString *)codeVerifier
                          completion:(DBOAuthCompletion)completion;
+
+/// Creates a `DBAccessTokenProvider` that wraps short-lived token for token refresh
+/// or a static access token provider for long-live token.
+/// @param token The `DBAccessToken` object.
+- (id<DBAccessTokenProvider>)accessTokenProviderForToken:(DBAccessToken *)token;
 
 @end
 

--- a/Source/ObjectiveDropboxOfficial/ObjectiveDropboxOfficial.xcodeproj/project.pbxproj
+++ b/Source/ObjectiveDropboxOfficial/ObjectiveDropboxOfficial.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		BF7E352C2488562F00DEDF84 /* DBLoadingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BF7E352A2488562F00DEDF84 /* DBLoadingViewController.m */; };
 		BF7E352E248858B600DEDF84 /* DBLoadingStatusDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = BF7E352D248858B600DEDF84 /* DBLoadingStatusDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF7E353024885A9A00DEDF84 /* DBOAuthMobile+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = BF7E352F24885A9A00DEDF84 /* DBOAuthMobile+Protected.h */; };
+		BFD93BC724905D8A006AB165 /* DBAccessTokenProviderImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = BFD93BC624905D8A006AB165 /* DBAccessTokenProviderImpl.m */; };
+		BFD93BC824905D8A006AB165 /* DBAccessTokenProviderImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = BFD93BC624905D8A006AB165 /* DBAccessTokenProviderImpl.m */; };
 		C43D4E69245748BB008DF48C /* DBStoneBase.m in Sources */ = {isa = PBXBuildFile; fileRef = C43D46EE245748AF008DF48C /* DBStoneBase.m */; };
 		C43D4E6A245748BB008DF48C /* DBStoneBase.m in Sources */ = {isa = PBXBuildFile; fileRef = C43D46EE245748AF008DF48C /* DBStoneBase.m */; };
 		C43D4E6B245748BB008DF48C /* DBStoneSerializers.m in Sources */ = {isa = PBXBuildFile; fileRef = C43D46EF245748AF008DF48C /* DBStoneSerializers.m */; };
@@ -3952,6 +3954,9 @@
 		BF7E352A2488562F00DEDF84 /* DBLoadingViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DBLoadingViewController.m; sourceTree = "<group>"; };
 		BF7E352D248858B600DEDF84 /* DBLoadingStatusDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DBLoadingStatusDelegate.h; sourceTree = "<group>"; };
 		BF7E352F24885A9A00DEDF84 /* DBOAuthMobile+Protected.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DBOAuthMobile+Protected.h"; sourceTree = "<group>"; };
+		BFC20EA424905395005A5E8F /* DBAccessTokenProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DBAccessTokenProvider.h; sourceTree = "<group>"; };
+		BFC20EA524905C57005A5E8F /* DBAccessTokenProvider+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DBAccessTokenProvider+Internal.h"; sourceTree = "<group>"; };
+		BFD93BC624905D8A006AB165 /* DBAccessTokenProviderImpl.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DBAccessTokenProviderImpl.m; sourceTree = "<group>"; };
 		C43D46EE245748AF008DF48C /* DBStoneBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DBStoneBase.m; sourceTree = "<group>"; };
 		C43D46EF245748AF008DF48C /* DBStoneSerializers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DBStoneSerializers.m; sourceTree = "<group>"; };
 		C43D46F0245748AF008DF48C /* DBStoneValidators.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DBStoneValidators.m; sourceTree = "<group>"; };
@@ -8325,6 +8330,7 @@
 		F297818C1E03692800876A73 /* OAuth */ = {
 			isa = PBXGroup;
 			children = (
+				BFC20EA424905395005A5E8F /* DBAccessTokenProvider.h */,
 				BF33F93C24874DED001F4072 /* DBOAuthResultCompletion.h */,
 				BF33F93D24874DED001F4072 /* DBOAuthTokenRequest.m */,
 				BF33F92124873F11001F4072 /* DBOAuthConstants.m */,
@@ -8340,6 +8346,7 @@
 				F29781921E03692800876A73 /* DBSDKKeychain.m */,
 				F29781931E03692800876A73 /* DBSharedApplicationProtocol.h */,
 				BF474D37248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.m */,
+				BFD93BC624905D8A006AB165 /* DBAccessTokenProviderImpl.m */,
 			);
 			path = OAuth;
 			sourceTree = "<group>";
@@ -8435,6 +8442,7 @@
 				BF33F92724873F12001F4072 /* DBOAuthUtils.h */,
 				BF33F93824873F3E001F4072 /* DBScopeRequest+Protected.h */,
 				F2C59AFC1E9C2EFC00E8D2E6 /* DBOAuthManager+Protected.h */,
+				BFC20EA524905C57005A5E8F /* DBAccessTokenProvider+Internal.h */,
 			);
 			path = OAuth;
 			sourceTree = "<group>";
@@ -12306,6 +12314,7 @@
 				C43D5CCD245748D9008DF48C /* DBFILEPROPERTIESRouteObjects.m in Sources */,
 				C43D5CB5245748D9008DF48C /* DBFILEREQUESTSUserAuthRoutes.m in Sources */,
 				BF33F92A24873F12001F4072 /* DBOAuthConstants.m in Sources */,
+				BFD93BC724905D8A006AB165 /* DBAccessTokenProviderImpl.m in Sources */,
 				C43D5CB3245748D9008DF48C /* DBCONTACTSUserAuthRoutes.m in Sources */,
 				C43D5C7B245748D8008DF48C /* DBCheckObjects.m in Sources */,
 				C43D5C95245748D8008DF48C /* DBUSERSUserAuthRoutes.m in Sources */,
@@ -12454,6 +12463,7 @@
 				C43D5324245748C4008DF48C /* DBFilePropertiesObjects.m in Sources */,
 				F29788D01E03692F00876A73 /* DBTeamClient.m in Sources */,
 				C43D5CB6245748D9008DF48C /* DBFILEREQUESTSUserAuthRoutes.m in Sources */,
+				BFD93BC824905D8A006AB165 /* DBAccessTokenProviderImpl.m in Sources */,
 				C43D5CF4245748D9008DF48C /* DBACCOUNTRouteObjects.m in Sources */,
 				C43D50A4245748BF008DF48C /* DBAsyncObjects.m in Sources */,
 				C43D50BC245748BF008DF48C /* DBTeamCommonObjects.m in Sources */,

--- a/Source/ObjectiveDropboxOfficial/ObjectiveDropboxOfficial.xcodeproj/project.pbxproj
+++ b/Source/ObjectiveDropboxOfficial/ObjectiveDropboxOfficial.xcodeproj/project.pbxproj
@@ -40,6 +40,10 @@
 		BF474D39248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = BF474D36248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.h */; };
 		BF474D3A248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = BF474D37248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.m */; };
 		BF474D3B248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = BF474D37248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.m */; };
+		BF6162C52491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.h in Headers */ = {isa = PBXBuildFile; fileRef = BF6162C32491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.h */; };
+		BF6162C62491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.h in Headers */ = {isa = PBXBuildFile; fileRef = BF6162C32491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.h */; };
+		BF6162C72491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.m in Sources */ = {isa = PBXBuildFile; fileRef = BF6162C42491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.m */; };
+		BF6162C82491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.m in Sources */ = {isa = PBXBuildFile; fileRef = BF6162C42491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.m */; };
 		BF7E352B2488562F00DEDF84 /* DBLoadingViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = BF7E35292488562F00DEDF84 /* DBLoadingViewController.h */; };
 		BF7E352C2488562F00DEDF84 /* DBLoadingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BF7E352A2488562F00DEDF84 /* DBLoadingViewController.m */; };
 		BF7E352E248858B600DEDF84 /* DBLoadingStatusDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = BF7E352D248858B600DEDF84 /* DBLoadingStatusDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -3950,6 +3954,8 @@
 		BF33F93D24874DED001F4072 /* DBOAuthTokenRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DBOAuthTokenRequest.m; sourceTree = "<group>"; };
 		BF474D36248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DBAccessToken+NSSecureCoding.h"; sourceTree = "<group>"; };
 		BF474D37248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "DBAccessToken+NSSecureCoding.m"; sourceTree = "<group>"; };
+		BF6162C32491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DBURLSessionTaskWithTokenRefresh.h; sourceTree = "<group>"; };
+		BF6162C42491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DBURLSessionTaskWithTokenRefresh.m; sourceTree = "<group>"; };
 		BF7E35292488562F00DEDF84 /* DBLoadingViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DBLoadingViewController.h; sourceTree = "<group>"; };
 		BF7E352A2488562F00DEDF84 /* DBLoadingViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DBLoadingViewController.m; sourceTree = "<group>"; };
 		BF7E352D248858B600DEDF84 /* DBLoadingStatusDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DBLoadingStatusDelegate.h; sourceTree = "<group>"; };
@@ -8323,6 +8329,7 @@
 				F29781881E03692800876A73 /* DBTransportDefaultClient.m */,
 				F24169451E523FD30038E306 /* DBTransportDefaultConfig.h */,
 				F24169461E523FEB0038E306 /* DBTransportDefaultConfig.m */,
+				BF6162C42491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.m */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -8382,6 +8389,7 @@
 		F2A2CE761E562817001D8449 /* Networking */ = {
 			isa = PBXGroup;
 			children = (
+				BF6162C32491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.h */,
 				F2A2CE771E562817001D8449 /* DBDelegate.h */,
 				F2A2CE781E562817001D8449 /* DBHandlerTypesInternal.h */,
 				F2A2CE791E562817001D8449 /* DBSDKReachability.h */,
@@ -9492,6 +9500,7 @@
 				C43D568D245748CB008DF48C /* DBTEAMLOGTeamFolderDowngradeDetails.h in Headers */,
 				C43D54A7245748C7008DF48C /* DBTEAMLOGSecondaryTeamRequestExpiredDetails.h in Headers */,
 				C43D5321245748C4008DF48C /* DBFILEPROPERTIESRemovePropertiesError.h in Headers */,
+				BF6162C52491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.h in Headers */,
 				C43D508B245748BF008DF48C /* DBFILEREQUESTSDeleteFileRequestArgs.h in Headers */,
 				C43D5A35245748D3008DF48C /* DBTEAMLOGDeviceChangeIpWebType.h in Headers */,
 				C43D598B245748D1008DF48C /* DBTEAMLOGWebSessionsChangeActiveSessionLimitDetails.h in Headers */,
@@ -11768,6 +11777,7 @@
 				C43D5B44245748D5008DF48C /* DBFILESLookupError.h in Headers */,
 				C43D592A245748D1008DF48C /* DBTEAMLOGGroupRemoveExternalIdDetails.h in Headers */,
 				C43D4F80245748BD008DF48C /* DBSHARINGSharedFolderMetadataBase.h in Headers */,
+				BF6162C62491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.h in Headers */,
 				C43D526E245748C3008DF48C /* DBTEAMTeamFolderRenameArg.h in Headers */,
 				C43D4F3E245748BC008DF48C /* DBSHARINGListFilesContinueError.h in Headers */,
 				C43D51AA245748C1008DF48C /* DBTEAMIncludeMembersArg.h in Headers */,
@@ -12334,6 +12344,7 @@
 				C43D5D03245748D9008DF48C /* DBTEAMTeamAuthRoutes.m in Sources */,
 				3C3C29741F7D757E00C54011 /* DBTransportBaseHostnameConfig.m in Sources */,
 				C43D5CE7245748D9008DF48C /* DBFILESRouteObjects.m in Sources */,
+				BF6162C72491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.m in Sources */,
 				C43D4F11245748BC008DF48C /* DBSecondaryEmailsObjects.m in Sources */,
 				C43D5CF1245748D9008DF48C /* DBCLOUDDOCSRouteObjects.m in Sources */,
 				C43D50BB245748BF008DF48C /* DBTeamCommonObjects.m in Sources */,
@@ -12440,6 +12451,7 @@
 				BF33F92B24873F12001F4072 /* DBOAuthConstants.m in Sources */,
 				C43D506A245748BF008DF48C /* DBFileRequestsObjects.m in Sources */,
 				F2A2CE9B1E562E46001D8449 /* DBCustomTasks.m in Sources */,
+				BF6162C82491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.m in Sources */,
 				C43D4E6A245748BB008DF48C /* DBStoneBase.m in Sources */,
 				C43D5CCC245748D9008DF48C /* DBPAPERRouteObjects.m in Sources */,
 				BF474D3B248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.m in Sources */,

--- a/Source/ObjectiveDropboxOfficial/Shared/Generated/Client/DBUserBaseClient.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Generated/Client/DBUserBaseClient.h
@@ -68,7 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) DBUSERSUserAuthRoutes *usersRoutes;
 
 /// Initializes the `DBUserBaseClient` object with a networking client.
-- (instancetype)initWithTransportClient:(id<DBTransportClient>)client;
+- (instancetype)initWithTransportClient:(id<DBTransportClient>)client NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/Source/ObjectiveDropboxOfficial/Shared/Generated/Client/DBUserBaseClient.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Generated/Client/DBUserBaseClient.h
@@ -67,6 +67,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// Routes within the `users` namespace.
 @property (nonatomic, readonly) DBUSERSUserAuthRoutes *usersRoutes;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Initializes the `DBUserBaseClient` object with a networking client.
 - (instancetype)initWithTransportClient:(id<DBTransportClient>)client NS_DESIGNATED_INITIALIZER;
 

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/DBClientsManager.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/DBClientsManager.m
@@ -3,7 +3,7 @@
 ///
 
 #import "DBClientsManager.h"
-#import "DBOAuthManager.h"
+#import "DBOAuthManager+Protected.h"
 #import "DBOAuthResult.h"
 #import "DBSDKKeychain.h"
 #import "DBTeamClient.h"
@@ -57,15 +57,6 @@ static NSMutableDictionary<NSString *, DBTeamClient *> *s_tokenUidToAuthorizedTe
   }
 }
 
-+ (void)setAuthorizedClient:(DBUserClient *)client tokenUid:(NSString *)tokenUid {
-  @synchronized(self) {
-    s_authorizedClient = client;
-    if (client && tokenUid) {
-      [[self class] addAuthorizedClient:client tokenUid:tokenUid];
-    }
-  }
-}
-
 + (NSDictionary<NSString *, DBUserClient *> *)authorizedClients {
   @synchronized(self) {
     // return shallow copy
@@ -79,55 +70,10 @@ static NSMutableDictionary<NSString *, DBTeamClient *> *s_tokenUidToAuthorizedTe
   }
 }
 
-+ (void)setAuthorizedTeamClient:(DBTeamClient *)client tokenUid:(NSString *)tokenUid {
-  @synchronized(self) {
-    s_authorizedTeamClient = client;
-    if (client && tokenUid) {
-      [[self class] addAuthorizedTeamClient:client tokenUid:tokenUid];
-    }
-  }
-}
-
 + (NSDictionary<NSString *, DBTeamClient *> *)authorizedTeamClients {
   @synchronized(self) {
     // return shallow copy
     return [NSMutableDictionary dictionaryWithDictionary:s_tokenUidToAuthorizedTeamClients];
-  }
-}
-
-+ (void)addAuthorizedClient:(DBUserClient *)client tokenUid:(NSString *)tokenUid {
-  @synchronized(self) {
-    s_tokenUidToAuthorizedClients[tokenUid] = client;
-  }
-}
-
-+ (void)addAuthorizedTeamClient:(DBTeamClient *)client tokenUid:(NSString *)tokenUid {
-  @synchronized(self) {
-    s_tokenUidToAuthorizedTeamClients[tokenUid] = client;
-  }
-}
-
-+ (void)removeAuthorizedClient:(NSString *)tokenUid {
-  @synchronized(self) {
-    [s_tokenUidToAuthorizedClients removeObjectForKey:tokenUid];
-  }
-}
-
-+ (void)removeAuthorizedTeamClient:(NSString *)tokenUid {
-  @synchronized(self) {
-    [s_tokenUidToAuthorizedTeamClients removeObjectForKey:tokenUid];
-  }
-}
-
-+ (void)removeAllAuthorizedClients {
-  @synchronized(self) {
-    [s_tokenUidToAuthorizedClients removeAllObjects];
-  }
-}
-
-+ (void)removeAllAuthorizedTeamClients {
-  @synchronized(self) {
-    [s_tokenUidToAuthorizedTeamClients removeAllObjects];
   }
 }
 
@@ -137,9 +83,7 @@ static NSMutableDictionary<NSString *, DBTeamClient *> *s_tokenUidToAuthorizedTe
 
   DBAccessToken *accessToken = [[DBOAuthManager sharedOAuthManager] retrieveAccessToken:tokenUid];
   if (accessToken) {
-    DBUserClient *userClient = [[DBUserClient alloc] initWithAccessToken:accessToken.accessToken
-                                                         transportConfig:[DBClientsManager transportConfig]];
-    [DBClientsManager setAuthorizedClient:userClient tokenUid:accessToken.uid];
+    [self db_addAuthorizedClientWithToken:accessToken setAsDefault:YES];
     return YES;
   }
   return NO;
@@ -151,9 +95,7 @@ static NSMutableDictionary<NSString *, DBTeamClient *> *s_tokenUidToAuthorizedTe
 
   DBAccessToken *accessToken = [[DBOAuthManager sharedOAuthManager] retrieveAccessToken:tokenUid];
   if (accessToken) {
-    DBTeamClient *teamClient = [[DBTeamClient alloc] initWithAccessToken:accessToken.accessToken
-                                                         transportConfig:[DBClientsManager transportConfig]];
-    [DBClientsManager setAuthorizedTeamClient:teamClient tokenUid:accessToken.uid];
+    [self db_addAuthorizedTeamClientWithToken:accessToken setAsDefault:YES];
     return YES;
   }
   return NO;
@@ -163,69 +105,16 @@ static NSMutableDictionary<NSString *, DBTeamClient *> *s_tokenUidToAuthorizedTe
               transportConfig:(DBTransportDefaultConfig *)transportConfig {
   NSAssert(![DBOAuthManager sharedOAuthManager], @"Only call `[DBClientsManager setupWith...]` once");
 
-  [[self class] setupHelperWithOAuthManager:oAuthManager transportConfig:transportConfig];
-  [[self class] setupAuthorizedClients];
+  [self db_setupHelperWithOAuthManager:oAuthManager transportConfig:transportConfig];
+  [self db_setupAuthorizedClients];
 }
 
 + (void)setupWithOAuthManagerTeam:(DBOAuthManager *)oAuthManager
                   transportConfig:(DBTransportDefaultConfig *)transportConfig {
   NSAssert(![DBOAuthManager sharedOAuthManager], @"Only call `[DBClientsManager setupWith...]` once");
 
-  [[self class] setupHelperWithOAuthManager:oAuthManager transportConfig:transportConfig];
-  [[self class] setupAuthorizedTeamClients];
-}
-
-+ (void)setupHelperWithOAuthManager:(DBOAuthManager *)oAuthManager
-                    transportConfig:(DBTransportDefaultConfig *)transportConfig {
-  [DBOAuthManager setSharedOAuthManager:oAuthManager];
-  [[self class] setTransportConfig:transportConfig];
-  [[self class] setAppKey:transportConfig.appKey];
-}
-
-+ (void)setupAuthorizedClients {
-  NSDictionary<NSString *, DBAccessToken *> *accessTokens =
-      [[DBOAuthManager sharedOAuthManager] retrieveAllAccessTokens];
-
-  if ([accessTokens count] > 0) {
-    DBAccessToken *firstToken = [[accessTokens allValues] objectAtIndex:0];
-
-    NSString *firstTokenUid = firstToken.uid;
-    NSString *firstAccessToken = firstToken.accessToken;
-
-    DBUserClient *userClient =
-        [[DBUserClient alloc] initWithAccessToken:firstAccessToken transportConfig:[DBClientsManager transportConfig]];
-    [DBClientsManager setAuthorizedClient:userClient tokenUid:firstTokenUid];
-
-    for (NSString *tokenUid in accessTokens) {
-      NSString *token = accessTokens[tokenUid].accessToken;
-      DBUserClient *client =
-          [[DBUserClient alloc] initWithAccessToken:token transportConfig:[DBClientsManager transportConfig]];
-      [self addAuthorizedClient:client tokenUid:tokenUid];
-    }
-  }
-}
-
-+ (void)setupAuthorizedTeamClients {
-  NSDictionary<NSString *, DBAccessToken *> *accessTokens =
-      [[DBOAuthManager sharedOAuthManager] retrieveAllAccessTokens];
-
-  if ([accessTokens count] > 0) {
-    DBAccessToken *firstToken = [[accessTokens allValues] objectAtIndex:0];
-
-    NSString *firstTokenUid = firstToken.uid;
-    NSString *firstAccessToken = firstToken.accessToken;
-
-    DBTeamClient *teamClient =
-        [[DBTeamClient alloc] initWithAccessToken:firstAccessToken transportConfig:[DBClientsManager transportConfig]];
-    [DBClientsManager setAuthorizedTeamClient:teamClient tokenUid:firstTokenUid];
-
-    for (NSString *tokenUid in accessTokens) {
-      NSString *token = accessTokens[tokenUid].accessToken;
-      DBTeamClient *client =
-          [[DBTeamClient alloc] initWithAccessToken:token transportConfig:[DBClientsManager transportConfig]];
-      [self addAuthorizedTeamClient:client tokenUid:tokenUid];
-    }
-  }
+  [self db_setupHelperWithOAuthManager:oAuthManager transportConfig:transportConfig];
+  [self db_setupAuthorizedTeamClients];
 }
 
 + (void)handleRedirectURL:(NSURL *)url completion:(DBOAuthCompletion)completion {
@@ -239,51 +128,15 @@ static NSMutableDictionary<NSString *, DBTeamClient *> *s_tokenUidToAuthorizedTe
 + (void)unlinkAndResetClient:(NSString *)tokenUid {
   if ([DBOAuthManager sharedOAuthManager]) {
     [[DBOAuthManager sharedOAuthManager] clearStoredAccessToken:tokenUid];
-    [[self class] resetClient:tokenUid];
+    [self db_resetClient:tokenUid];
   }
 }
 
 + (void)unlinkAndResetClients {
   if ([DBOAuthManager sharedOAuthManager]) {
     [[DBOAuthManager sharedOAuthManager] clearStoredAccessTokens];
-    [[self class] resetClients];
+    [self db_resetClients];
   }
-}
-
-+ (void)resetClient:(NSString *)tokenUid {
-  [DBClientsManager removeAuthorizedClient:tokenUid];
-  [DBClientsManager removeAuthorizedTeamClient:tokenUid];
-
-  DBAccessToken *token = [[DBOAuthManager sharedOAuthManager] retrieveAccessToken:tokenUid];
-  if (token.accessToken == [DBClientsManager authorizedClient].accessToken) {
-    [DBClientsManager setAuthorizedClient:nil tokenUid:nil];
-
-    NSDictionary<NSString *, DBUserClient *> *authorizedClientsCopy = [DBClientsManager authorizedClients];
-
-    if ([authorizedClientsCopy count] > 0) {
-      NSString *firstUid = [authorizedClientsCopy allKeys][0];
-      [DBClientsManager setAuthorizedClient:authorizedClientsCopy[firstUid] tokenUid:tokenUid];
-    }
-  }
-
-  if (token.accessToken == [DBClientsManager authorizedTeamClient].accessToken) {
-    [DBClientsManager setAuthorizedTeamClient:nil tokenUid:nil];
-
-    NSDictionary<NSString *, DBTeamClient *> *authorizedTeamClientsCopy = [DBClientsManager authorizedTeamClients];
-
-    if ([authorizedTeamClientsCopy count] > 0) {
-      NSString *firstUid = [authorizedTeamClientsCopy allKeys][0];
-      [DBClientsManager setAuthorizedTeamClient:authorizedTeamClientsCopy[firstUid] tokenUid:tokenUid];
-    }
-  }
-}
-
-+ (void)resetClients {
-  [DBClientsManager setAuthorizedClient:nil tokenUid:nil];
-  [DBClientsManager setAuthorizedTeamClient:nil tokenUid:nil];
-
-  [DBClientsManager removeAllAuthorizedClients];
-  [DBClientsManager removeAllAuthorizedTeamClients];
 }
 
 + (BOOL)checkAndPerformV1TokenMigration:(DBTokenMigrationResponseBlock)responseBlock
@@ -295,6 +148,158 @@ static NSMutableDictionary<NSString *, DBTeamClient *> *s_tokenUidToAuthorizedTe
 
 #pragma mark Private helpers
 
++ (void)db_addAuthorizedClientWithToken:(DBAccessToken *)token
+                           setAsDefault:(BOOL)setAsDefault {
+  id<DBAccessTokenProvider> tokenProvider = [[DBOAuthManager sharedOAuthManager] accessTokenProviderForToken:token];
+  DBUserClient *client = [[DBUserClient alloc] initWithAccessTokenProvider:tokenProvider
+                                                                  tokenUid:token.uid
+                                                           transportConfig:[self transportConfig]];
+  [self db_addAuthorizedClient:client tokenUid:token.uid setAsDefault:setAsDefault];
+}
+
++ (void)db_setAuthorizedClient:(DBUserClient *)client {
+  @synchronized(self) {
+    s_authorizedClient = client;
+  }
+}
+
++ (void)db_addAuthorizedClient:(DBUserClient *)client
+                      tokenUid:(NSString *)tokenUid
+                  setAsDefault:(BOOL)setAsDefault {
+  @synchronized(self) {
+    s_tokenUidToAuthorizedClients[tokenUid] = client;
+    if (setAsDefault) {
+      [self db_setAuthorizedClient:client];
+    }
+  }
+}
+
++ (void)db_addAuthorizedTeamClientWithToken:(DBAccessToken *)token
+                               setAsDefault:(BOOL)setAsDefault {
+  if (![DBOAuthManager sharedOAuthManager]) {
+    return;
+  }
+
+  id<DBAccessTokenProvider> tokenProvider = [[DBOAuthManager sharedOAuthManager] accessTokenProviderForToken:token];
+  DBTeamClient *client = [[DBTeamClient alloc] initWithAccessTokenProvider:tokenProvider
+                                                                  tokenUid:token.uid
+                                                           transportConfig:[self transportConfig]];
+  [self db_addAuthorizedTeamClient:client tokenUid:token.uid setAsDefault:setAsDefault];
+}
+
++ (void)db_setAuthorizedTeamClient:(DBTeamClient *)client {
+  @synchronized(self) {
+    s_authorizedTeamClient = client;
+  }
+}
+
++ (void)db_addAuthorizedTeamClient:(DBTeamClient *)client
+                          tokenUid:(NSString *)tokenUid
+                      setAsDefault:(BOOL)setAsDefault {
+  @synchronized(self) {
+    s_tokenUidToAuthorizedTeamClients[tokenUid] = client;
+    if (setAsDefault) {
+      [self db_setAuthorizedTeamClient:client];
+    }
+  }
+}
+
++ (DBUserClient *)db_authorizedClient:(NSString *)tokenUid {
+  @synchronized(self) {
+    return s_tokenUidToAuthorizedClients[tokenUid];
+  }
+}
+
++ (DBTeamClient *)db_authorizedTeamClient:(NSString *)tokenUid {
+  @synchronized(self) {
+    return s_tokenUidToAuthorizedTeamClients[tokenUid];
+  }
+}
+
++ (void)db_removeAuthorizedClient:(NSString *)tokenUid {
+  @synchronized(self) {
+    [s_tokenUidToAuthorizedClients removeObjectForKey:tokenUid];
+  }
+}
+
++ (void)db_removeAuthorizedTeamClient:(NSString *)tokenUid {
+  @synchronized(self) {
+    [s_tokenUidToAuthorizedTeamClients removeObjectForKey:tokenUid];
+  }
+}
+
++ (void)db_removeAllAuthorizedClients {
+  @synchronized(self) {
+    [s_tokenUidToAuthorizedClients removeAllObjects];
+  }
+}
+
++ (void)db_removeAllAuthorizedTeamClients {
+  @synchronized(self) {
+    [s_tokenUidToAuthorizedTeamClients removeAllObjects];
+  }
+}
+
++ (void)db_setupHelperWithOAuthManager:(DBOAuthManager *)oAuthManager
+                    transportConfig:(DBTransportDefaultConfig *)transportConfig {
+  [DBOAuthManager setSharedOAuthManager:oAuthManager];
+  [self setTransportConfig:transportConfig];
+  [self setAppKey:transportConfig.appKey];
+}
+
++ (void)db_setupAuthorizedClients {
+  NSArray<DBAccessToken *> *accessTokens =
+      [[[DBOAuthManager sharedOAuthManager] retrieveAllAccessTokens] allValues];
+  for (NSUInteger i = 0; i < accessTokens.count; i++) {
+    [self db_addAuthorizedClientWithToken:accessTokens[i] setAsDefault:i == 0];
+  }
+}
+
++ (void)db_setupAuthorizedTeamClients {
+  NSArray<DBAccessToken *> *accessTokens =
+      [[[DBOAuthManager sharedOAuthManager] retrieveAllAccessTokens] allValues];
+  for (NSUInteger i = 0; i < accessTokens.count; i++) {
+    [self db_addAuthorizedTeamClientWithToken:accessTokens[i] setAsDefault:i == 0];
+  }
+}
+
++ (void)db_resetClients {
+  [DBClientsManager db_setAuthorizedClient:nil];
+  [DBClientsManager db_setAuthorizedTeamClient:nil];
+
+  [DBClientsManager db_removeAllAuthorizedClients];
+  [DBClientsManager db_removeAllAuthorizedTeamClients];
+}
+
++ (void)db_resetClient:(NSString *)tokenUid {
+  BOOL shouldResetDefaultUserClient = [self db_authorizedClient:tokenUid] == [DBClientsManager authorizedClient];
+  [self db_removeAuthorizedClient:tokenUid];
+  if (shouldResetDefaultUserClient) {
+    [DBClientsManager db_setAuthorizedClient:nil];
+
+    NSDictionary<NSString *, DBUserClient *> *authorizedClientsCopy = [DBClientsManager authorizedClients];
+
+    if ([authorizedClientsCopy count] > 0) {
+      NSString *firstUid = [authorizedClientsCopy allKeys][0];
+      [DBClientsManager db_setAuthorizedClient:authorizedClientsCopy[firstUid]];
+    }
+  }
+
+  BOOL shouldResetDefaultTeamClient =
+    [self db_authorizedTeamClient:tokenUid] == [DBClientsManager authorizedTeamClient];
+  [self db_removeAuthorizedTeamClient:tokenUid];
+  if (shouldResetDefaultTeamClient) {
+    [DBClientsManager db_setAuthorizedTeamClient:nil];
+
+    NSDictionary<NSString *, DBTeamClient *> *authorizedTeamClientsCopy = [DBClientsManager authorizedTeamClients];
+
+    if ([authorizedTeamClientsCopy count] > 0) {
+      NSString *firstUid = [authorizedTeamClientsCopy allKeys][0];
+      [DBClientsManager db_setAuthorizedTeamClient:authorizedTeamClientsCopy[firstUid]];
+    }
+  }
+}
+
 + (void)db_handleRedirectURL:(NSURL *)url
                       isTeam:(BOOL)isTeam
                   completion:(DBOAuthCompletion)completion {
@@ -305,13 +310,9 @@ static NSMutableDictionary<NSString *, DBTeamClient *> *s_tokenUidToAuthorizedTe
     if ([result isSuccess]) {
       DBAccessToken *token = result.accessToken;
       if (isTeam) {
-        DBTeamClient *teamClient = [[DBTeamClient alloc] initWithAccessToken:token.accessToken
-                                                             transportConfig:[DBClientsManager transportConfig]];
-        [DBClientsManager setAuthorizedTeamClient:teamClient tokenUid:token.uid];
+        [self db_addAuthorizedTeamClientWithToken:token setAsDefault:YES];
       } else {
-        DBUserClient *userClient = [[DBUserClient alloc] initWithAccessToken:token.accessToken
-                                                             transportConfig:[DBClientsManager transportConfig]];
-        [DBClientsManager setAuthorizedClient:userClient tokenUid:token.uid];
+        [self db_addAuthorizedClientWithToken:token setAsDefault:YES];
       }
     }
     completion(result);

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/DBTeamClient.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/DBTeamClient.h
@@ -7,7 +7,9 @@
 #import "DBTeamBaseClient.h"
 
 @class DBUserClient;
+@class DBTransportDefaultClient;
 @class DBTransportDefaultConfig;
+@protocol DBAccessTokenProvider;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -25,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, copy, nullable) NSString *tokenUid;
 
 ///
-/// Convenience constructor.
+/// Convenience initializer.
 ///
 /// Uses standard network configuration parameters.
 ///
@@ -36,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithAccessToken:(NSString *)accessToken;
 
 ///
-/// Convenience constructor.
+/// Convenience initializer.
 ///
 /// @param accessToken The Dropbox OAuth 2.0 access token used to make requests.
 /// @param transportConfig A wrapper around the different parameters that can be set to change network calling behavior.
@@ -48,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
                     transportConfig:(nullable DBTransportDefaultConfig *)transportConfig;
 
 ///
-/// Full constructor.
+/// Convenience initializer.
 ///
 /// @param accessToken The Dropbox OAuth 2.0 access token used to make requests.
 /// @param tokenUid Identifies a unique Dropbox account. Used for the multi Dropbox account case where client objects
@@ -61,6 +63,29 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithAccessToken:(NSString *)accessToken
                            tokenUid:(nullable NSString *)tokenUid
                     transportConfig:(nullable DBTransportDefaultConfig *)transportConfig;
+
+///
+/// Convenience initializer.
+///
+/// @param accessTokenProvider A `DBAccessTokenProvider` that provides access token and token refresh functionality.
+/// @param tokenUid Identifies a unique Dropbox account. Used for the multi Dropbox account case where client objects
+/// are each associated with a particular Dropbox account.
+/// @param transportConfig A wrapper around the different parameters that can be set to change network calling behavior.
+/// `DBTransportDefaultConfig` offers a number of different constructors to customize networking settings.
+///
+/// @return An initialized instance.
+///
+- (instancetype)initWithAccessTokenProvider:(id<DBAccessTokenProvider>)accessTokenProvider
+                                   tokenUid:(nullable NSString *)tokenUid
+                            transportConfig:(nullable DBTransportDefaultConfig *)transportConfig;
+
+/// Designated initializer.
+///
+/// @param client A `DBTransportDefaultClient` used to make network requests.
+///
+/// @return An initialized instance.
+///
+- (instancetype)initWithTransportClient:(DBTransportDefaultClient *)client NS_DESIGNATED_INITIALIZER;
 
 ///
 /// Returns a `DBUserClient` instance that can be used to make API calls on behalf of the designated team member.

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/DBTeamClient.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/DBTeamClient.m
@@ -4,6 +4,7 @@
 
 #import "DBTeamClient.h"
 
+#import "DBAccessTokenProvider.h"
 #import "DBTransportDefaultClient.h"
 #import "DBTransportDefaultConfig.h"
 #import "DBUserClient.h"
@@ -25,25 +26,42 @@
   DBTransportDefaultClient *transportClient = [[DBTransportDefaultClient alloc] initWithAccessToken:accessToken
                                                                                            tokenUid:tokenUid
                                                                                     transportConfig:transportConfig];
-  return [super initWithTransportClient:transportClient];
+  return [self initWithTransportClient:transportClient];
 }
 
-- (DBUserClient *)userClientWithMemberId:(NSString *)memberId {
-  return [[DBUserClient alloc] initWithAccessToken:_transportClient.accessToken
-                                   transportConfig:[(DBTransportDefaultClient *)_transportClient
-                                                       duplicateTransportConfigWithAsMemberId:memberId]];
+- (instancetype)initWithAccessTokenProvider:(id<DBAccessTokenProvider>)accessTokenProvider
+                                   tokenUid:(NSString *)tokenUid
+                            transportConfig:(DBTransportDefaultConfig *)transportConfig {
+  DBTransportDefaultClient *transportClient =
+    [[DBTransportDefaultClient alloc] initWithAccessTokenProvider:accessTokenProvider
+                                                         tokenUid:tokenUid
+                                                  transportConfig:transportConfig];
+  return [self initWithTransportClient:transportClient];
 }
 
-- (void)updateAccessToken:(NSString *)accessToken {
-  _transportClient.accessToken = accessToken;
+- (instancetype)initWithTransportClient:(DBTransportDefaultClient *)client {
+  if (self = [super initWithTransportClient:client]) {
+    _tokenUid = client.tokenUid;
+  }
+  return self;
 }
 
 - (NSString *)accessToken {
-  return _transportClient.accessToken;
+  return _transportClient.accessTokenProvider.accessToken;
 }
 
 - (BOOL)isAuthorized {
-  return _transportClient.accessToken != nil;
+  return _transportClient.accessTokenProvider != nil;
+}
+
+- (DBUserClient *)userClientWithMemberId:(NSString *)memberId {
+  DBTransportDefaultConfig *transportConfig = nil;
+  if ([_transportClient isKindOfClass:[DBTransportDefaultClient class]]) {
+    transportConfig = [(DBTransportDefaultClient *)_transportClient duplicateTransportConfigWithAsMemberId:memberId];
+  }
+  return [[DBUserClient alloc] initWithAccessTokenProvider:_transportClient.accessTokenProvider
+                                                  tokenUid:_tokenUid
+                                           transportConfig:transportConfig];
 }
 
 @end

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/DBUserClient.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/DBUserClient.h
@@ -7,7 +7,9 @@
 #import "DBCOMMONPathRoot.h"
 #import "DBUserBaseClient.h"
 
+@class DBTransportDefaultClient;
 @class DBTransportDefaultConfig;
+@protocol DBAccessTokenProvider;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -25,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, copy, nullable) NSString *tokenUid;
 
 ///
-/// Convenience constructor.
+/// Convenience initializer.
 ///
 /// Uses standard network configuration parameters.
 ///
@@ -36,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithAccessToken:(NSString *)accessToken;
 
 ///
-/// Convenience constructor.
+/// Convenience initializer.
 ///
 /// @param accessToken The Dropbox OAuth 2.0 access token used to make requests.
 /// @param transportConfig A wrapper around the different parameters that can be set to change network calling behavior.
@@ -48,9 +50,9 @@ NS_ASSUME_NONNULL_BEGIN
                     transportConfig:(nullable DBTransportDefaultConfig *)transportConfig;
 
 ///
-/// Full constructor.
+/// Convenience initializer.
 ///
-/// @param accessToken The Dropbox OAuth 2.0 access token used to make requests.
+/// @param accessToken The (long-lived) Dropbox OAuth 2.0 access token used to make requests.
 /// @param tokenUid Identifies a unique Dropbox account. Used for the multi Dropbox account case where client objects
 /// are each associated with a particular Dropbox account.
 /// @param transportConfig A wrapper around the different parameters that can be set to change network calling behavior.
@@ -61,6 +63,29 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithAccessToken:(NSString *)accessToken
                            tokenUid:(nullable NSString *)tokenUid
                     transportConfig:(nullable DBTransportDefaultConfig *)transportConfig;
+
+///
+/// Convenience initializer.
+///
+/// @param accessTokenProvider A `DBAccessTokenProvider` that provides access token and token refresh functionality.
+/// @param tokenUid Identifies a unique Dropbox account. Used for the multi Dropbox account case where client objects
+/// are each associated with a particular Dropbox account.
+/// @param transportConfig A wrapper around the different parameters that can be set to change network calling behavior.
+/// `DBTransportDefaultConfig` offers a number of different constructors to customize networking settings.
+///
+/// @return An initialized instance.
+///
+- (instancetype)initWithAccessTokenProvider:(id<DBAccessTokenProvider>)accessTokenProvider
+                                   tokenUid:(nullable NSString *)tokenUid
+                            transportConfig:(nullable DBTransportDefaultConfig *)transportConfig;
+
+/// Designated initializer.
+///
+/// @param client A `DBTransportDefaultClient` used to make network requests.
+///
+/// @return An initialized instance.
+///
+- (instancetype)initWithTransportClient:(DBTransportDefaultClient *)client NS_DESIGNATED_INITIALIZER;
 
 ///
 /// Returns a `DBUserClient` instance that can be used to make API calls with given path root value.

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/DBUserClient.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/DBUserClient.m
@@ -3,6 +3,8 @@
 ///
 
 #import "DBUserClient.h"
+
+#import "DBAccessTokenProvider.h"
 #import "DBTransportDefaultClient.h"
 #import "DBTransportDefaultConfig.h"
 
@@ -21,30 +23,44 @@
                            tokenUid:(NSString *)tokenUid
                     transportConfig:(DBTransportDefaultConfig *)transportConfig {
   DBTransportDefaultClient *transportClient = [[DBTransportDefaultClient alloc] initWithAccessToken:accessToken
-                                                                                           tokenUid:_tokenUid
+                                                                                           tokenUid:tokenUid
                                                                                     transportConfig:transportConfig];
-  if (self = [super initWithTransportClient:transportClient]) {
-    _tokenUid = tokenUid;
+  return [self initWithTransportClient:transportClient];
+}
+
+- (instancetype)initWithAccessTokenProvider:(id<DBAccessTokenProvider>)accessTokenProvider
+                                   tokenUid:(NSString *)tokenUid
+                            transportConfig:(DBTransportDefaultConfig *)transportConfig {
+  DBTransportDefaultClient *transportClient =
+    [[DBTransportDefaultClient alloc] initWithAccessTokenProvider:accessTokenProvider
+                                                         tokenUid:tokenUid
+                                                  transportConfig:transportConfig];
+  return [self initWithTransportClient:transportClient];
+}
+
+- (instancetype)initWithTransportClient:(DBTransportDefaultClient *)client {
+  if (self = [super initWithTransportClient:client]) {
+    _tokenUid = client.tokenUid;
   }
   return self;
 }
 
 - (DBUserClient *)withPathRoot:(DBCOMMONPathRoot *)pathRoot {
-  return [[DBUserClient alloc]
-      initWithAccessToken:_transportClient.accessToken
-          transportConfig:[(DBTransportDefaultClient *)_transportClient duplicateTransportConfigWithPathRoot:pathRoot]];
-}
-
-- (void)updateAccessToken:(NSString *)accessToken {
-  _transportClient.accessToken = accessToken;
+  DBTransportDefaultConfig *transportConfig = nil;
+  if ([_transportClient isKindOfClass:[DBTransportDefaultClient class]]) {
+    transportConfig = [(DBTransportDefaultClient *)_transportClient duplicateTransportConfigWithPathRoot:pathRoot];
+  }
+  return [[DBUserClient alloc] initWithAccessTokenProvider:_transportClient.accessTokenProvider
+                                                  tokenUid:_tokenUid
+                                           transportConfig:transportConfig];
 }
 
 - (NSString *)accessToken {
-  return _transportClient.accessToken;
+  return _transportClient.accessTokenProvider.accessToken;
 }
 
 - (BOOL)isAuthorized {
-  return _transportClient.accessToken != nil;
+  return _transportClient.accessTokenProvider != nil;
 }
 
 @end

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBDelegate.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBDelegate.m
@@ -203,12 +203,12 @@
   return tmpOutputPath;
 }
 
-- (void)addProgressHandler:(NSURLSessionTask *)task
-                   session:(NSURLSession *)session
-           progressHandler:(void (^)(int64_t, int64_t, int64_t))handler
-      progressHandlerQueue:(NSOperationQueue *)handlerQueue {
+- (void)addProgressHandlerForTaskWithIdentifier:(NSUInteger)identifier
+                                        session:(NSURLSession *)session
+                                progressHandler:(void (^)(int64_t, int64_t, int64_t))handler
+                           progressHandlerQueue:(NSOperationQueue *)handlerQueue {
   [_delegateQueue addOperationWithBlock:^{
-    NSNumber *taskId = @(task.taskIdentifier);
+    NSNumber *taskId = @(identifier);
 
     DBSessionData *sessionData = [self sessionDataWithSession:session];
     DBProgressData *progressData = sessionData.progressData[taskId];
@@ -230,12 +230,12 @@
 
 #pragma mark - Add RPC-style handler
 
-- (void)addRpcResponseHandler:(NSURLSessionTask *)task
-                      session:(NSURLSession *)session
-              responseHandler:(DBRpcResponseBlockStorage)handler
-         responseHandlerQueue:(NSOperationQueue *)handlerQueue {
+- (void)addRpcResponseHandlerForTaskWithIdentifier:(NSUInteger)identifier
+                                           session:(NSURLSession *)session
+                                   responseHandler:(DBRpcResponseBlockStorage)handler
+                              responseHandlerQueue:(NSOperationQueue *)handlerQueue {
   [_delegateQueue addOperationWithBlock:^{
-    NSNumber *taskId = @(task.taskIdentifier);
+    NSNumber *taskId = @(identifier);
     DBSessionData *sessionData = [self sessionDataWithSession:session];
 
     DBCompletionData *completionData = sessionData.completionData[taskId];
@@ -262,12 +262,12 @@
 
 #pragma mark - Add Upload-style handler
 
-- (void)addUploadResponseHandler:(NSURLSessionTask *)task
-                         session:(NSURLSession *)session
-                 responseHandler:(DBUploadResponseBlockStorage)handler
-            responseHandlerQueue:(NSOperationQueue *)handlerQueue {
+- (void)addUploadResponseHandlerForTaskWithIdentifier:(NSUInteger)identifier
+                                              session:(NSURLSession *)session
+                                      responseHandler:(DBUploadResponseBlockStorage)handler
+                                 responseHandlerQueue:(NSOperationQueue *)handlerQueue {
   [_delegateQueue addOperationWithBlock:^{
-    NSNumber *taskId = @(task.taskIdentifier);
+    NSNumber *taskId = @(identifier);
     DBSessionData *sessionData = [self sessionDataWithSession:session];
 
     DBCompletionData *completionData = sessionData.completionData[taskId];
@@ -294,12 +294,12 @@
 
 #pragma mark - Add Download-style handler
 
-- (void)addDownloadResponseHandler:(NSURLSessionTask *)task
-                           session:(NSURLSession *)session
-                   responseHandler:(DBDownloadResponseBlockStorage)handler
-              responseHandlerQueue:(NSOperationQueue *)handlerQueue {
+- (void)addDownloadResponseHandlerForTaskWithIdentifier:(NSUInteger)identifier
+                                                session:(NSURLSession *)session
+                                        responseHandler:(DBDownloadResponseBlockStorage)handler
+                                   responseHandlerQueue:(NSOperationQueue *)handlerQueue {
   [_delegateQueue addOperationWithBlock:^{
-    NSNumber *taskId = @(task.taskIdentifier);
+    NSNumber *taskId = @(identifier);
     DBSessionData *sessionData = [self sessionDataWithSession:session];
 
     DBCompletionData *completionData = sessionData.completionData[taskId];

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasks.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasks.h
@@ -35,6 +35,9 @@ NS_ASSUME_NONNULL_BEGIN
   NSOperationQueue *_queue;
 }
 
+/// A unique string identifier for this task.
+@property (nonatomic, readonly, copy) NSString *taskIdentifier;
+
 /// Tracks the number of times this task has been retried.
 @property (nonatomic) int retryCount;
 

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasks.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasks.m
@@ -21,6 +21,7 @@
     _route = route;
     _queue = nil;
     _tokenUid = [tokenUid copy];
+    _taskIdentifier = [[NSUUID UUID].UUIDString copy];
   }
   return self;
 }

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasksImpl.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasksImpl.m
@@ -15,37 +15,34 @@
 @implementation DBRpcTaskImpl {
   DBRpcTaskImpl *_selfRetained;
   DBRpcResponseBlockImpl _responseBlock;
+  id<DBURLSessionTask> _task;
 }
 
-- (instancetype)initWithTask:(NSURLSessionDataTask *)task
+- (instancetype)initWithTask:(id<DBURLSessionTask>)task
                     tokenUid:(NSString *)tokenUid
-                     session:(NSURLSession *)session
-                    delegate:(DBDelegate *)delegate
                        route:(DBRoute *)route {
   self = [super initWithRoute:route tokenUid:tokenUid];
   if (self) {
-    _dataTask = task;
-    _session = session;
-    _delegate = delegate;
+    _task = task;
     _selfRetained = self;
   }
   return self;
 }
 
 - (void)cancel {
-  [_dataTask cancel];
+  [_task cancel];
 }
 
 - (void)suspend {
-  [_dataTask suspend];
+  [_task suspend];
 }
 
 - (void)resume {
-  [_dataTask resume];
+  [_task resume];
 }
 
 - (void)start {
-  [_dataTask resume];
+  [_task resume];
 }
 
 - (void)cleanup {
@@ -58,14 +55,10 @@
 }
 
 - (DBTask *)restart {
-  NSURLRequest *request = [_dataTask.originalRequest copy];
-  NSURLSessionDataTask *task = [_session dataTaskWithRequest:request];
-  DBRpcTaskImpl *sdkTask =
-      [[DBRpcTaskImpl alloc] initWithTask:task tokenUid:self.tokenUid session:_session delegate:_delegate route:_route];
+  DBRpcTaskImpl *sdkTask = [[DBRpcTaskImpl alloc] initWithTask:[_task duplicate] tokenUid:self.tokenUid route:_route];
   sdkTask.retryCount += 1;
   [sdkTask setResponseBlock:_responseBlock queue:_queue];
-  [task resume];
-
+  [sdkTask resume];
   return sdkTask;
 }
 
@@ -79,7 +72,7 @@
                                                                   cleanupBlock:^{
                                                                     [self cleanup];
                                                                   }];
-  [_delegate addRpcResponseHandler:_dataTask session:_session responseHandler:storageBlock responseHandlerQueue:queue];
+  [_task setResponseBlock:[DBURLSessionTaskResponseBlockWrapper withRpcResponseBlock:storageBlock] queue:queue];
   return self;
 }
 
@@ -88,7 +81,7 @@
 }
 
 - (DBRpcTask *)setProgressBlock:(DBProgressBlock)progressBlock queue:(NSOperationQueue *)queue {
-  [_delegate addProgressHandler:_dataTask session:_session progressHandler:progressBlock progressHandlerQueue:queue];
+  [_task setProgressBlock:progressBlock queue:queue];
   return self;
 }
 
@@ -99,24 +92,21 @@
 @implementation DBUploadTaskImpl {
   DBUploadTaskImpl *_selfRetained;
   DBUploadResponseBlockImpl _responseBlock;
+  id<DBURLSessionTask> _uploadTask;
 }
 
-- (instancetype)initWithTask:(NSURLSessionUploadTask *)task
+- (instancetype)initWithTask:(id<DBURLSessionTask>)task
                     tokenUid:(NSString *)tokenUid
-                     session:(NSURLSession *)session
-                    delegate:(DBDelegate *)delegate
-                       route:(DBRoute *)route
-                    inputUrl:(NSURL *)inputUrl
-                   inputData:(NSData *)inputData {
+                       route:(DBRoute *)route {
   self = [super initWithRoute:route tokenUid:tokenUid];
   if (self) {
     _uploadTask = task;
-    _session = session;
-    _delegate = delegate;
-    _inputUrl = inputUrl;
-    _inputData = inputData;
   }
   return self;
+}
+
+- (NSURLSession *)session {
+  return _uploadTask.session;
 }
 
 - (void)cancel {
@@ -145,28 +135,12 @@
 }
 
 - (DBTask *)restart {
-  NSURLRequest *request = [_uploadTask.originalRequest copy];
-  NSURLSessionUploadTask *task = nil;
-  self.retryCount += 1;
-  if (_inputUrl) {
-    task = [_session uploadTaskWithRequest:request fromFile:self->_inputUrl];
-  } else if (_inputData) {
-    task = [_session uploadTaskWithRequest:request fromData:self->_inputData];
-  } else {
-    task = [_session uploadTaskWithStreamedRequest:request];
-  }
-
-  DBUploadTaskImpl *sdkTask = [[DBUploadTaskImpl alloc] initWithTask:task
+  DBUploadTaskImpl *sdkTask = [[DBUploadTaskImpl alloc] initWithTask:[_uploadTask duplicate]
                                                             tokenUid:self.tokenUid
-                                                             session:_session
-                                                            delegate:_delegate
-                                                               route:_route
-                                                            inputUrl:_inputUrl
-                                                           inputData:_inputData];
+                                                               route:_route];
   sdkTask.retryCount += 1;
   [sdkTask setResponseBlock:_responseBlock queue:_queue];
   [sdkTask resume];
-
   return sdkTask;
 }
 
@@ -180,11 +154,8 @@
                                                                      cleanupBlock:^{
                                                                        [self cleanup];
                                                                      }];
-  [_delegate addUploadResponseHandler:_uploadTask
-                              session:_session
-                      responseHandler:storageBlock
-                 responseHandlerQueue:queue];
-
+  [_uploadTask setResponseBlock:[DBURLSessionTaskResponseBlockWrapper withUploadResponseBlock:storageBlock]
+                          queue:queue];
   return self;
 }
 
@@ -193,7 +164,7 @@
 }
 
 - (DBUploadTask *)setProgressBlock:(DBProgressBlock)progressBlock queue:(NSOperationQueue *)queue {
-  [_delegate addProgressHandler:_uploadTask session:_session progressHandler:progressBlock progressHandlerQueue:queue];
+  [_uploadTask setProgressBlock:progressBlock queue:queue];
   return self;
 }
 
@@ -204,25 +175,27 @@
 @implementation DBDownloadUrlTaskImpl {
   DBDownloadUrlTaskImpl *_selfRetained;
   DBDownloadUrlResponseBlockImpl _responseBlock;
+  id<DBURLSessionTask> _downloadUrlTask;
 }
 
-- (instancetype)initWithTask:(NSURLSessionDownloadTask *)task
+- (instancetype)initWithTask:(id<DBURLSessionTask>)task
                     tokenUid:(NSString *)tokenUid
-                     session:(NSURLSession *)session
-                    delegate:(DBDelegate *)delegate
                        route:(DBRoute *)route
                    overwrite:(BOOL)overwrite
                  destination:(NSURL *)destination {
   self = [super initWithRoute:route tokenUid:tokenUid];
   if (self) {
     _downloadUrlTask = task;
-    _session = session;
-    _delegate = delegate;
     _overwrite = overwrite;
     _destination = destination;
   }
   return self;
 }
+
+- (NSURLSession *)session {
+  return _downloadUrlTask.session;
+}
+
 
 - (void)cancel {
   [_downloadUrlTask cancel];
@@ -250,19 +223,14 @@
 }
 
 - (DBTask *)restart {
-  NSURLRequest *request = [_downloadUrlTask.originalRequest copy];
-  NSURLSessionDownloadTask *task = [_session downloadTaskWithRequest:request];
-  DBDownloadUrlTaskImpl *sdkTask = [[DBDownloadUrlTaskImpl alloc] initWithTask:task
+  DBDownloadUrlTaskImpl *sdkTask = [[DBDownloadUrlTaskImpl alloc] initWithTask:[_downloadUrlTask duplicate]
                                                                       tokenUid:self.tokenUid
-                                                                       session:_session
-                                                                      delegate:_delegate
                                                                          route:_route
                                                                      overwrite:_overwrite
                                                                    destination:_destination];
   sdkTask.retryCount += 1;
   [sdkTask setResponseBlock:_responseBlock queue:_queue];
-  [task resume];
-
+  [sdkTask resume];
   return sdkTask;
 }
 
@@ -276,11 +244,9 @@
                                                                        cleanupBlock:^{
                                                                          [self cleanup];
                                                                        }];
-  [_delegate addDownloadResponseHandler:_downloadUrlTask
-                                session:_session
-                        responseHandler:storageBlock
-                   responseHandlerQueue:queue];
 
+  [_downloadUrlTask setResponseBlock:[DBURLSessionTaskResponseBlockWrapper withDownloadResponseBlock:storageBlock]
+                               queue:queue];
   return self;
 }
 
@@ -289,10 +255,7 @@
 }
 
 - (DBDownloadUrlTask *)setProgressBlock:(DBProgressBlock)progressBlock queue:(NSOperationQueue *)queue {
-  [_delegate addProgressHandler:_downloadUrlTask
-                        session:_session
-                progressHandler:progressBlock
-           progressHandlerQueue:queue];
+  [_downloadUrlTask setProgressBlock:progressBlock queue:queue];
   return self;
 }
 
@@ -303,20 +266,21 @@
 @implementation DBDownloadDataTaskImpl {
   DBDownloadDataTaskImpl *_selfRetained;
   DBDownloadDataResponseBlockImpl _responseBlock;
+  id<DBURLSessionTask> _downloadDataTask;
 }
 
-- (instancetype)initWithTask:(NSURLSessionDownloadTask *)task
+- (instancetype)initWithTask:(id<DBURLSessionTask>)task
                     tokenUid:(NSString *)tokenUid
-                     session:(NSURLSession *)session
-                    delegate:(DBDelegate *)delegate
                        route:(DBRoute *)route {
   self = [super initWithRoute:route tokenUid:tokenUid];
   if (self) {
     _downloadDataTask = task;
-    _session = session;
-    _delegate = delegate;
   }
   return self;
+}
+
+- (NSURLSession *)session {
+  return _downloadDataTask.session;
 }
 
 - (void)cancel {
@@ -345,17 +309,12 @@
 }
 
 - (DBTask *)restart {
-  NSURLRequest *request = [_downloadDataTask.originalRequest copy];
-  NSURLSessionDownloadTask *task = [_session downloadTaskWithRequest:request];
-  DBDownloadDataTaskImpl *sdkTask = [[DBDownloadDataTaskImpl alloc] initWithTask:task
+  DBDownloadDataTaskImpl *sdkTask = [[DBDownloadDataTaskImpl alloc] initWithTask:[_downloadDataTask duplicate]
                                                                         tokenUid:self.tokenUid
-                                                                         session:_session
-                                                                        delegate:_delegate
                                                                            route:_route];
   sdkTask.retryCount += 1;
   [sdkTask setResponseBlock:_responseBlock queue:_queue];
-  [task resume];
-
+  [sdkTask resume];
   return sdkTask;
 }
 
@@ -370,11 +329,8 @@
                                                                        cleanupBlock:^{
                                                                          [self cleanup];
                                                                        }];
-  [_delegate addDownloadResponseHandler:_downloadDataTask
-                                session:_session
-                        responseHandler:storageBlock
-                   responseHandlerQueue:queue];
-
+  [_downloadDataTask setResponseBlock:[DBURLSessionTaskResponseBlockWrapper withDownloadResponseBlock:storageBlock]
+                                queue:queue];
   return self;
 }
 
@@ -383,10 +339,7 @@
 }
 
 - (DBDownloadDataTask *)setProgressBlock:(DBProgressBlock)progressBlock queue:(NSOperationQueue *)queue {
-  [_delegate addProgressHandler:_downloadDataTask
-                        session:_session
-                progressHandler:progressBlock
-           progressHandlerQueue:queue];
+  [_downloadDataTask setProgressBlock:progressBlock queue:queue];
   return self;
 }
 

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasksStorage.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasksStorage.m
@@ -55,7 +55,7 @@
   @synchronized(self) {
     if (!_cancel) {
       NSString *sessionId = task.session.configuration.identifier ?: kDBSDKForegroundSessionId;
-      NSString *key = [NSString stringWithFormat:@"%@/%lu", sessionId, (unsigned long)task.uploadTask.taskIdentifier];
+      NSString *key = [NSString stringWithFormat:@"%@/%@", sessionId, task.taskIdentifier];
       [_uploadTasks setObject:task forKey:key];
     } else {
       [task cancel];
@@ -66,7 +66,7 @@
 - (void)removeUploadTask:(DBUploadTaskImpl *)task {
   @synchronized(self) {
     NSString *sessionId = task.session.configuration.identifier ?: kDBSDKForegroundSessionId;
-    NSString *key = [NSString stringWithFormat:@"%@/%lu", sessionId, (unsigned long)task.uploadTask.taskIdentifier];
+    NSString *key = [NSString stringWithFormat:@"%@/%@", sessionId, task.taskIdentifier];
     [_uploadTasks removeObjectForKey:key];
   }
 }
@@ -76,7 +76,7 @@
     if (!_cancel) {
       NSString *sessionId = task.session.configuration.identifier ?: kDBSDKForegroundSessionId;
       NSString *key =
-          [NSString stringWithFormat:@"%@/%lu", sessionId, (unsigned long)task.downloadUrlTask.taskIdentifier];
+          [NSString stringWithFormat:@"%@/%@", sessionId, task.taskIdentifier];
       [_downloadUrlTasks setObject:task forKey:key];
     } else {
       [task cancel];
@@ -88,7 +88,7 @@
   @synchronized(self) {
     NSString *sessionId = task.session.configuration.identifier ?: kDBSDKForegroundSessionId;
     NSString *key =
-        [NSString stringWithFormat:@"%@/%lu", sessionId, (unsigned long)task.downloadUrlTask.taskIdentifier];
+        [NSString stringWithFormat:@"%@/%@", sessionId, task.taskIdentifier];
     [_downloadUrlTasks removeObjectForKey:key];
   }
 }
@@ -98,7 +98,7 @@
     if (!_cancel) {
       NSString *sessionId = task.session.configuration.identifier ?: kDBSDKForegroundSessionId;
       NSString *key =
-          [NSString stringWithFormat:@"%@/%lu", sessionId, (unsigned long)task.downloadDataTask.taskIdentifier];
+          [NSString stringWithFormat:@"%@/%@", sessionId, task.taskIdentifier];
       [_downloadDataTasks setObject:task forKey:key];
     } else {
       [task cancel];
@@ -110,7 +110,7 @@
   @synchronized(self) {
     NSString *sessionId = task.session.configuration.identifier ?: kDBSDKForegroundSessionId;
     NSString *key =
-        [NSString stringWithFormat:@"%@/%lu", sessionId, (unsigned long)task.downloadDataTask.taskIdentifier];
+        [NSString stringWithFormat:@"%@/%@", sessionId, task.taskIdentifier];
     [_downloadDataTasks removeObjectForKey:key];
   }
 }

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseClient.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseClient.h
@@ -6,13 +6,14 @@
 #import <Foundation/Foundation.h>
 
 @class DBTransportBaseConfig;
+@protocol DBAccessTokenProvider;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface DBTransportBaseClient : NSObject
 
-/// The Dropbox OAuth2 access token used to make requests.
-@property (nonatomic, readonly, copy, nullable) NSString *accessToken;
+/// The Dropbox OAuth2 access token provider used to make requests.
+@property (nonatomic, readonly, nullable) id<DBAccessTokenProvider> accessTokenProvider;
 
 /// Identifies a unique Dropbox account. Used for the multi Dropbox account case where client objects are each
 /// associated with a particular Dropbox account.
@@ -40,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, copy, nullable) NSDictionary<NSString *, NSString *> *additionalHeaders;
 
 ///
-/// Full constructor.
+/// Convenience initializer.
 ///
 /// @param accessToken The Dropbox OAuth2 access token used to make requests.
 /// @param tokenUid Identifies a unique Dropbox account. Used for the multi Dropbox account case where client objects
@@ -53,6 +54,22 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithAccessToken:(nullable NSString *)accessToken
                            tokenUid:(nullable NSString *)tokenUid
                     transportConfig:(DBTransportBaseConfig *)transportConfig;
+
+///
+/// Designated initializer.
+///
+/// @param accessTokenProvider The `DBAccessTokenProvider` that provides a Dropbox OAuth2 access token
+/// used to make requests.
+/// @param tokenUid Identifies a unique Dropbox account. Used for the multi Dropbox account case where client objects
+/// are each associated with a particular Dropbox account.
+/// @param transportConfig A wrapper around the different parameters that can be set to change network calling behavior.
+/// `DBTransportDefaultConfig` offers a number of different constructors to customize networking settings.
+///
+/// @return An initialized instance.
+///
+- (instancetype)initWithAccessTokenProvider:(nullable id<DBAccessTokenProvider>)accessTokenProvider
+                                   tokenUid:(nullable NSString *)tokenUid
+                            transportConfig:(DBTransportBaseConfig *)transportConfig NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseClient.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseClient.m
@@ -4,6 +4,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import "DBAccessTokenProvider+Internal.h"
 #import "DBAUTHAccessError.h"
 #import "DBAUTHAuthError.h"
 #import "DBAUTHRateLimitError.h"
@@ -26,8 +27,18 @@
 - (instancetype)initWithAccessToken:(NSString *)accessToken
                            tokenUid:(NSString *)tokenUid
                     transportConfig:(DBTransportBaseConfig *)transportConfig {
+  DBLongLivedAccessTokenProvider *provider = nil;
+  if (accessToken) {
+    provider = [[DBLongLivedAccessTokenProvider alloc] initWithTokenString:accessToken];
+  }
+  return [self initWithAccessTokenProvider:provider tokenUid:tokenUid transportConfig:transportConfig];
+}
+
+- (instancetype)initWithAccessTokenProvider:(id<DBAccessTokenProvider>)accessTokenProvider
+                                   tokenUid:(NSString *)tokenUid
+                            transportConfig:(DBTransportBaseConfig *)transportConfig {
   if (self = [super init]) {
-    _accessToken = accessToken;
+    _accessTokenProvider = accessTokenProvider;
     _tokenUid = [tokenUid copy];
     _appKey = transportConfig.appKey;
     _appSecret = transportConfig.appSecret;
@@ -79,8 +90,9 @@
       NSData *authData = [authString dataUsingEncoding:NSUTF8StringEncoding];
       [headers setObject:[NSString stringWithFormat:@"Basic %@", [authData base64EncodedStringWithOptions:0]]
                   forKey:@"Authorization"];
-    } else {
-      [headers setObject:[NSString stringWithFormat:@"Bearer %@", _accessToken] forKey:@"Authorization"];
+    } else if (_accessTokenProvider) {
+      [headers setObject:[NSString stringWithFormat:@"Bearer %@", _accessTokenProvider.accessToken]
+                  forKey:@"Authorization"];
     }
   }
 

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportClientProtocol.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportClientProtocol.h
@@ -11,13 +11,14 @@
 @class DBRoute;
 @class DBRpcTask;
 @class DBUploadTask;
+@protocol DBAccessTokenProvider;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol DBTransportClient <NSObject>
 
-/// The Dropbox OAuth2 access token used to make requests.
-@property (nonatomic, copy, nullable) NSString *accessToken;
+/// The Dropbox OAuth2 access token provider used to make requests.
+@property (nonatomic, nullable) id<DBAccessTokenProvider> accessTokenProvider;
 
 #pragma mark - RPC-style request
 

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportDefaultClient.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportDefaultClient.m
@@ -3,6 +3,8 @@
 ///
 
 #import "DBTransportDefaultClient.h"
+
+#import "DBAccessTokenProvider+Internal.h"
 #import "DBDelegate.h"
 #import "DBFILESRouteObjects.h"
 #import "DBSDKConstants.h"
@@ -27,7 +29,16 @@
 - (instancetype)initWithAccessToken:(NSString *)accessToken
                            tokenUid:(NSString *)tokenUid
                     transportConfig:(DBTransportDefaultConfig *)transportConfig {
-  if (self = [super initWithAccessToken:accessToken tokenUid:tokenUid transportConfig:transportConfig]) {
+  return [self initWithAccessTokenProvider:[[DBLongLivedAccessTokenProvider alloc] initWithTokenString:accessToken]
+                                  tokenUid:tokenUid
+                           transportConfig:transportConfig];
+}
+
+- (instancetype)initWithAccessTokenProvider:(id<DBAccessTokenProvider>)accessTokenProvider
+                                   tokenUid:(NSString *)tokenUid
+                            transportConfig:(DBTransportDefaultConfig *)transportConfig {
+  self = [super initWithAccessTokenProvider:accessTokenProvider tokenUid:tokenUid transportConfig:transportConfig];
+  if (self) {
     _delegateQueue = transportConfig.delegateQueue ?: [NSOperationQueue new];
     _delegateQueue.maxConcurrentOperationCount = 1;
     _delegate = [[DBDelegate alloc] initWithQueue:_delegateQueue];

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBURLSessionTaskWithTokenRefresh.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBURLSessionTaskWithTokenRefresh.m
@@ -1,0 +1,222 @@
+///
+/// Copyright (c) 2020 Dropbox, Inc. All rights reserved.
+///
+
+#import "DBURLSessionTaskWithTokenRefresh.h"
+
+#import "DBAccessTokenProvider.h"
+#import "DBOAuthResult.h"
+#import "DBDelegate.h"
+
+@interface DBURLSessionTaskResponseBlockWrapper ()
+
+@property (nonatomic, strong, nullable) DBRpcResponseBlockStorage rpcResponseBlock;
+@property (nonatomic, strong, nullable) DBUploadResponseBlockStorage uploadResponseBlock;
+@property (nonatomic, strong, nullable) DBDownloadResponseBlockStorage downloadResponseBlock;
+
+@end
+
+@implementation DBURLSessionTaskResponseBlockWrapper
+
++ (DBURLSessionTaskResponseBlockWrapper *)withRpcResponseBlock:(DBRpcResponseBlockStorage)responseBlock {
+  DBURLSessionTaskResponseBlockWrapper *wrapper = [[DBURLSessionTaskResponseBlockWrapper alloc] init];
+  wrapper.rpcResponseBlock = responseBlock;
+  return wrapper;
+}
+
++ (DBURLSessionTaskResponseBlockWrapper *)withUploadResponseBlock:(DBUploadResponseBlockStorage)responseBlock {
+  DBURLSessionTaskResponseBlockWrapper *wrapper = [[DBURLSessionTaskResponseBlockWrapper alloc] init];
+  wrapper.uploadResponseBlock = responseBlock;
+  return wrapper;
+}
+
++ (DBURLSessionTaskResponseBlockWrapper *)withDownloadResponseBlock:(DBDownloadResponseBlockStorage)responseBlock {
+  DBURLSessionTaskResponseBlockWrapper *wrapper = [[DBURLSessionTaskResponseBlockWrapper alloc] init];
+  wrapper.downloadResponseBlock = responseBlock;
+  return wrapper;
+}
+
+@end
+
+@interface DBURLSessionTaskWithTokenRefresh ()
+
+@property (nonatomic, weak) DBDelegate *taskDelegate;
+@property (nonatomic, strong) DBURLSessionTaskCreationBlock taskCreationBlock;
+@property (nonatomic, strong) id<DBAccessTokenProvider> tokenProvider;
+@property (nonatomic, strong) DBProgressBlock progressBlock;
+@property (nonatomic, strong) NSOperationQueue *progressQueue;
+@property (nonatomic, strong) DBURLSessionTaskResponseBlockWrapper *responseBlockWrapper;
+@property (nonatomic, strong) NSOperationQueue *responseQueue;
+@property (nonatomic, strong) dispatch_queue_t serialQueue;
+@property (nonatomic, strong, nullable) NSURLSessionTask *sessionTask;
+@property (nonatomic, assign) BOOL cancelled;
+@property (nonatomic, assign) BOOL suspended;
+@property (nonatomic, assign) BOOL started;
+
+@end
+
+@implementation DBURLSessionTaskWithTokenRefresh
+
+@synthesize session = _session;
+
+- (instancetype)initWithTaskCreationBlock:(DBURLSessionTaskCreationBlock)taskCreationBlock
+                             taskDelegate:(DBDelegate *)taskDelegate
+                               urlSession:(NSURLSession *)urlSession
+                            tokenProvider:(id<DBAccessTokenProvider>)tokenProvider {
+  self = [super init];
+  if (self) {
+    _taskCreationBlock = taskCreationBlock;
+    _taskDelegate = taskDelegate;
+    _session = urlSession;
+    _tokenProvider = tokenProvider;
+    dispatch_queue_attr_t qosAttribute =
+      dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INITIATED, 0);
+    _serialQueue =
+      dispatch_queue_create("com.dropbox.dropbox_sdk_obj_c.DBURLSessionTaskWithTokenRefresh.queue", qosAttribute);
+  }
+  return self;
+}
+
+- (id<DBURLSessionTask>)duplicate {
+  return [[DBURLSessionTaskWithTokenRefresh alloc] initWithTaskCreationBlock:_taskCreationBlock
+                                                                taskDelegate:_taskDelegate
+                                                                  urlSession:_session
+                                                               tokenProvider:_tokenProvider];
+}
+
+- (void)cancel {
+  dispatch_async(_serialQueue, ^{
+    self->_cancelled = YES;
+    [self->_sessionTask cancel];
+  });
+}
+
+- (void)suspend {
+  dispatch_async(_serialQueue, ^{
+    self->_suspended = YES;
+    [self->_sessionTask suspend];
+  });
+}
+
+- (void)resume {
+  dispatch_async(_serialQueue, ^{
+    self->_started = YES;
+    if (self->_sessionTask) {
+      [self->_sessionTask resume];
+    } else {
+      [self db_start];
+    }
+  });
+}
+
+- (void)setProgressBlock:(DBProgressBlock)progressBlock
+                   queue:(NSOperationQueue *)queue {
+  dispatch_async(_serialQueue, ^{
+    self->_progressBlock = progressBlock;
+    self->_progressQueue = queue;
+    [self db_setProgressHandlerIfNecessary];
+  });
+}
+
+- (void)setResponseBlock:(DBURLSessionTaskResponseBlockWrapper *)responseBlockWrapper
+                   queue:(NSOperationQueue *)queue {
+  dispatch_async(_serialQueue, ^{
+    self->_responseBlockWrapper = responseBlockWrapper;
+    self->_responseQueue = queue;
+    [self db_setResponseHandlerIfNecessary];
+  });
+}
+
+#pragma mark Private helpers
+
+- (void)db_start {
+  DBOAuthCompletion completion = ^(DBOAuthResult *result) {
+    dispatch_async(self->_serialQueue, ^{
+      [self db_handleTokenRefreshResult:result];
+    });
+  };
+
+  if (_tokenProvider) {
+    [_tokenProvider refreshAccessTokenIfNecessary:completion];
+  } else {
+    completion(nil);
+  }
+}
+
+- (void)db_handleTokenRefreshResult:(DBOAuthResult *)result {
+  if ([result isError] && result.errorType != DBAuthInvalidGrant) {
+    // Refresh failed, due to an error that's not invalid grant, e.g. A refresh request timed out.
+    // Complete request with error immediately, so developers could retry and get access token refreshed.
+    // Otherwise, the API request may proceed with an expired access token which would lead to
+    // a false positive auth error.
+    [self db_completeWithError:result.nsError];
+  } else {
+    // Refresh succeeded or a refresh is not required, i.e. access token is valid, continue request normally.
+    // Or
+    // Refresh failed due to invalid grant, e.g. refresh token revoked by user.
+    // Continue, and the API call would failed with an auth error that developers can handle properly.
+    // e.g. Sign out the user upon auth error.
+    [self db_initializeSessionTask];
+  }
+}
+
+- (void)db_initializeSessionTask {
+  _sessionTask = _taskCreationBlock();
+  [self db_setProgressHandlerIfNecessary];
+  [self db_setResponseHandlerIfNecessary];
+  if (_cancelled) {
+    [_sessionTask cancel];
+  } else if (_suspended) {
+    [_sessionTask suspend];
+  } else if (_started) {
+    [_sessionTask resume];
+  }
+}
+
+- (void)db_setProgressHandlerIfNecessary {
+  if (_sessionTask && _progressBlock) {
+    [_taskDelegate addProgressHandlerForTaskWithIdentifier:_sessionTask.taskIdentifier
+                                                   session:_session
+                                           progressHandler:_progressBlock
+                                      progressHandlerQueue:_progressQueue];
+  }
+}
+
+- (void)db_setResponseHandlerIfNecessary {
+  if (_sessionTask == nil || _responseBlockWrapper == nil) {
+    return;
+  }
+
+  if (_responseBlockWrapper.rpcResponseBlock) {
+    [_taskDelegate addRpcResponseHandlerForTaskWithIdentifier:_sessionTask.taskIdentifier
+                                                      session:_session
+                                              responseHandler:_responseBlockWrapper.rpcResponseBlock
+                                         responseHandlerQueue:_responseQueue];
+  } else if (_responseBlockWrapper.uploadResponseBlock) {
+    [_taskDelegate addUploadResponseHandlerForTaskWithIdentifier:_sessionTask.taskIdentifier
+                                                         session:_session
+                                                 responseHandler:_responseBlockWrapper.uploadResponseBlock
+                                            responseHandlerQueue:_responseQueue];
+  } else if (_responseBlockWrapper.downloadResponseBlock) {
+    [_taskDelegate addDownloadResponseHandlerForTaskWithIdentifier:_sessionTask.taskIdentifier
+                                                           session:_session
+                                                   responseHandler:_responseBlockWrapper.downloadResponseBlock
+                                              responseHandlerQueue:_responseQueue];
+  }
+}
+
+- (void)db_completeWithError:(NSError *)error {
+  NSOperationQueue *queue = _responseQueue ?: [NSOperationQueue mainQueue];
+  DBURLSessionTaskResponseBlockWrapper *blockWrapper = _responseBlockWrapper;
+  [queue addOperationWithBlock:^{
+    if (blockWrapper.rpcResponseBlock) {
+      blockWrapper.rpcResponseBlock(nil, nil, error);
+    } else if (blockWrapper.uploadResponseBlock) {
+      blockWrapper.uploadResponseBlock(nil, nil, error);
+    } else if (blockWrapper.downloadResponseBlock) {
+      blockWrapper.downloadResponseBlock(nil, nil, error);
+    }
+  }];
+}
+
+@end

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBAccessTokenProvider.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBAccessTokenProvider.h
@@ -1,0 +1,21 @@
+///
+/// Copyright (c) 2020 Dropbox, Inc. All rights reserved.
+///
+
+#import "DBOAuthResultCompletion.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Protocol for objects that provide an access token and offer a way to refresh (short-lived) token.
+@protocol DBAccessTokenProvider <NSObject>
+
+/// Returns an access token for making user auth API calls.
+@property (nonatomic, readonly) NSString *accessToken;
+
+/// This refreshes the access token if it's expired or about to expire.
+/// The refresh result will be passed back via the completion block.
+- (void)refreshAccessTokenIfNecessary:(DBOAuthCompletion)completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBAccessTokenProviderImpl.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBAccessTokenProviderImpl.m
@@ -1,0 +1,112 @@
+///
+/// Copyright (c) 2020 Dropbox, Inc. All rights reserved.
+///
+
+#import "DBAccessTokenProvider+Internal.h"
+
+#import "DBOAuthResult.h"
+
+@implementation DBLongLivedAccessTokenProvider
+
+@synthesize accessToken = _accessToken;
+
+- (instancetype)initWithTokenString:(NSString *)tokenString {
+  self = [super init];
+  if (self) {
+    _accessToken = tokenString;
+  }
+  return self;
+}
+
+- (void)refreshAccessTokenIfNecessary:(DBOAuthCompletion)completion {
+  // Complete with empty result, because it doesn't need a refresh.
+  completion(nil);
+}
+
+@end
+
+@interface DBShortLivedAccessTokenProvider ()
+
+@property (nonatomic, strong) DBAccessToken *token;
+@property (nonatomic, strong) id<DBAccessTokenRefreshing> tokenRefresher;
+@property (nonatomic, strong) dispatch_queue_t queue;
+@property (nonatomic, strong) NSMutableArray<DBOAuthCompletion> *completionBlocks;
+
+
+@end
+
+@implementation DBShortLivedAccessTokenProvider
+
+- (instancetype)initWithToken:(DBAccessToken *)token tokenRefresher:(id<DBAccessTokenRefreshing>)tokenRefresher {
+  self = [super init];
+  if (self) {
+    _token = token;
+    _tokenRefresher = tokenRefresher;
+    dispatch_queue_attr_t qosAttribute =
+      dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_CONCURRENT, QOS_CLASS_USER_INITIATED, 0);
+    _queue = dispatch_queue_create("com.dropbox.dropbox_sdk_obj_c.DBShortLivedAccessTokenProvider.queue", qosAttribute);
+    _completionBlocks = [NSMutableArray new];
+  }
+  return self;
+}
+
+- (NSString *)accessToken {
+  __block NSString *tokenString = nil;
+  dispatch_sync(_queue, ^{
+    tokenString = _token.accessToken;
+  });
+  return tokenString;
+}
+
+- (void)refreshAccessTokenIfNecessary:(DBOAuthCompletion)completion {
+  dispatch_barrier_async(_queue, ^{
+    if (![self db_shouldRefresh]) {
+      completion(nil);
+      return;
+    }
+
+    // Ensure subsequent calls don't initiate more refresh requests, if one is in progress.
+    BOOL refreshInProgress = [self db_refreshInProgress];
+    [self->_completionBlocks addObject:completion];
+    if (!refreshInProgress) {
+      __weak typeof(self) weakSelf = self;
+      [self->_tokenRefresher refreshAccessToken:self->_token
+                                   scopes:@[]
+                                    queue:nil
+                               completion:^(DBOAuthResult *result) {
+        [weakSelf db_handleRefreshResult:result];
+      }];
+    }
+  });
+}
+
+/// Refresh if it's about to expire (5 minutes from expiration) or already expired.
+- (BOOL)db_shouldRefresh {
+  NSTimeInterval expirationTimestamp = _token.tokenExpirationTimestamp;
+  if (!expirationTimestamp) {
+    return NO;
+  }
+
+  NSDate *fiveMinutesBeforeExpire = [NSDate dateWithTimeIntervalSince1970:expirationTimestamp - 300];
+  BOOL dateHasPassed = fiveMinutesBeforeExpire.timeIntervalSinceNow < 0;
+  return dateHasPassed;
+}
+
+- (BOOL)db_refreshInProgress {
+  return _completionBlocks.count > 0;
+}
+
+- (void)db_handleRefreshResult:(DBOAuthResult *)result {
+  dispatch_barrier_async(_queue, ^{
+    if ([result isSuccess] && result.accessToken) {
+      self->_token = result.accessToken;
+    }
+    for (DBOAuthCompletion block in self->_completionBlocks) {
+      block(result);
+    }
+    [self->_completionBlocks removeAllObjects];
+  });
+}
+
+@end
+

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthResult.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthResult.h
@@ -94,6 +94,10 @@ typedef NS_ENUM(NSInteger, DBOAuthErrorType) {
 /// @note Ensure the `isError` method returns true before accessing, otherwise a runtime exception will be raised.
 @property (nonatomic, readonly, copy) NSString *errorDescription;
 
+/// The `NSError` form of the error result.
+/// @note Ensure the `isError` method returns true before accessing, otherwise a runtime exception will be raised.
+@property (nonatomic, readonly) NSError *nsError;
+
 #pragma mark - Constructors
 
 ///

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthResult.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthResult.m
@@ -66,7 +66,7 @@
 }
 
 + (DBOAuthResult *)unknownErrorWithErrorDescription:(NSString *)errorDescription {
-  return  [[DBOAuthResult alloc] initWithErrorType:DBAuthUnknown errorDescription:errorDescription];
+  return [[DBOAuthResult alloc] initWithErrorType:DBAuthUnknown errorDescription:errorDescription];
 }
 
 #pragma mark - Tag state methods
@@ -122,6 +122,14 @@
                 format:@"Invalid tag: required `DBAuthError`, but was %@.", [self tagName]];
   }
   return _errorDescription;
+}
+
+- (NSError *)nsError {
+  if (_tag != DBAuthError) {
+    [NSException raise:@"IllegalStateException"
+                format:@"Invalid tag: required `DBAuthError`, but was %@.", [self tagName]];
+  }
+  return [NSError errorWithDomain:@"com.dropbox.dropbox_sdk_obj_c.oauth.error" code:_errorType userInfo:nil];
 }
 
 #pragma mark - Description method


### PR DESCRIPTION
- Created `DBAccessTokenProvider` protocol to dynamically provide access token for API requests.
-- Default implementations are provided for long-lived token and short-lived token.
- Refactored API client classes to use `DBAccessTokenProvider` instead of static access token string.
- In `DBClientsManager`:
-- Updated API clients setup methods to use appropriate access token providers.
-- Added the `db_` prefix to private methods and group them all together.