### PR TITLE
Short-lived token refresh support - part 3

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Headers/Internal/Networking/DBDelegate.h
+++ b/Source/ObjectiveDropboxOfficial/Headers/Internal/Networking/DBDelegate.h
@@ -45,10 +45,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithQueue:(nullable NSOperationQueue *)delegateQueue;
 
 ///
-/// Enqueues a handler to be executed periodically to retrieve information on the progress of the supplied
-/// `NSURLSessionTask` task for the corresponding Upload-style request.
+/// Enqueues a handler to be executed periodically to retrieve information on the progress of the
+/// `NSURLSessionTask` identified by the supplied task identifier for the corresponding Upload-style request.
 ///
-/// @param task The `NSURLSessionTask` task associated with the API request.
+/// @param identifier The identifier of the `NSURLSessionTask` task associated with the API request.
 /// @param session The `NSURLSession` session associated with the API request.
 /// @param handler The progress block to be executed in the event of a request update. The first argument is the number
 /// of bytes downloaded. The second argument is the number of total bytes downloaded. And the third argument is the
@@ -56,61 +56,61 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param handlerQueue The operation queue on which to execute progress handler code. If nil, then the progress queue
 /// is the queue with which the delegate object was instantiated.
 ///
-- (void)addProgressHandler:(NSURLSessionTask *)task
-                   session:(NSURLSession *)session
-           progressHandler:(DBProgressBlock)handler
-      progressHandlerQueue:(nullable NSOperationQueue *)handlerQueue;
+- (void)addProgressHandlerForTaskWithIdentifier:(NSUInteger)identifier
+                                        session:(NSURLSession *)session
+                                progressHandler:(DBProgressBlock)handler
+                           progressHandlerQueue:(nullable NSOperationQueue *)handlerQueue;
 
 #pragma mark - Add RPC-style handlers
 
 ///
-/// Enqueues a handler to be executed upon completion of the supplied `NSURLSessionTask` task for the corresponding
-/// RPC-style request.
+/// Enqueues a handler to be executed upon completion of the `NSURLSessionTask` identified by the supplied
+/// task identifier for the corresponding RPC-style request.
 ///
-/// @param task The `NSURLSessionTask` task associated with the API request.
+/// @param identifier The identifier of the `NSURLSessionTask` task associated with the API request.
 /// @param session The `NSURLSession` session associated with the API request.
 /// @param handler The handler block to be executed in the event of a successful or unsuccessful network request.
 /// @param handlerQueue The operation queue on which to execute response handler code. If nil, then the response queue
 /// is the queue with which the delegate object was instantiated.
 ///
-- (void)addRpcResponseHandler:(NSURLSessionTask *)task
-                      session:(NSURLSession *)session
-              responseHandler:(DBRpcResponseBlockStorage)handler
-         responseHandlerQueue:(nullable NSOperationQueue *)handlerQueue;
+- (void)addRpcResponseHandlerForTaskWithIdentifier:(NSUInteger)identifier
+                                           session:(NSURLSession *)session
+                                   responseHandler:(DBRpcResponseBlockStorage)handler
+                              responseHandlerQueue:(nullable NSOperationQueue *)handlerQueue;
 
 #pragma mark - Add Upload-style handlers
 
 ///
-/// Enqueues a handler to be executed upon completion of the supplied `NSURLSessionTask` task for the corresponding
-/// Upload-style request.
+/// Enqueues a handler to be executed upon completion of the `NSURLSessionTask` task identified by the supplied
+/// task identifier for the corresponding Upload-style request.
 ///
-/// @param task The `NSURLSessionTask` task associated with the API request.
+/// @param identifier The identifier of the `NSURLSessionTask` task associated with the API request.
 /// @param session The `NSURLSession` session associated with the API request.
 /// @param handler The handler block to be executed in the event of a successful or unsuccessful network request.
 /// @param handlerQueue The operation queue on which to execute response handler code. If nil, then the response queue
 /// is the queue with which the delegate object was instantiated.
 ///
-- (void)addUploadResponseHandler:(NSURLSessionTask *)task
-                         session:(NSURLSession *)session
-                 responseHandler:(DBUploadResponseBlockStorage)handler
-            responseHandlerQueue:(nullable NSOperationQueue *)handlerQueue;
+- (void)addUploadResponseHandlerForTaskWithIdentifier:(NSUInteger)identifier
+                                              session:(NSURLSession *)session
+                                      responseHandler:(DBUploadResponseBlockStorage)handler
+                                 responseHandlerQueue:(nullable NSOperationQueue *)handlerQueue;
 
 #pragma mark - Add Download-style handlers
 
 ///
-/// Enqueues a handler to be executed upon completion of the supplied `NSURLSessionTask` task for the corresponding
-/// Download-style request.
+/// Enqueues a handler to be executed upon completion of the `NSURLSessionTask` task identified by the supplied
+/// task identifier for the corresponding Download-style request.
 ///
-/// @param task The `NSURLSessionTask` task associated with the API request.
+/// @param identifier The identifier of the `NSURLSessionTask` task associated with the API request.
 /// @param session The `NSURLSession` session associated with the API request.
 /// @param handler The handler block to be executed in the event of a successful or unsuccessful network request.
 /// @param handlerQueue The operation queue on which to execute response handler code. If nil, then the response queue
 /// is the queue with which the delegate object was instantiated.
 ///
-- (void)addDownloadResponseHandler:(NSURLSessionTask *)task
-                           session:(NSURLSession *)session
-                   responseHandler:(DBDownloadResponseBlockStorage)handler
-              responseHandlerQueue:(nullable NSOperationQueue *)handlerQueue;
+- (void)addDownloadResponseHandlerForTaskWithIdentifier:(NSUInteger)identifier
+                                                session:(NSURLSession *)session
+                                        responseHandler:(DBDownloadResponseBlockStorage)handler
+                                   responseHandlerQueue:(nullable NSOperationQueue *)handlerQueue;
 
 @end
 

--- a/Source/ObjectiveDropboxOfficial/Headers/Internal/Networking/DBTasksImpl.h
+++ b/Source/ObjectiveDropboxOfficial/Headers/Internal/Networking/DBTasksImpl.h
@@ -7,6 +7,7 @@
 #import "DBHandlerTypes.h"
 #import "DBTasks.h"
 #import "DBTasksImpl.h"
+#import "DBURLSessionTaskWithTokenRefresh.h"
 
 @class DBBatchUploadData;
 @class DBDelegate;
@@ -19,32 +20,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface DBRpcTaskImpl : DBRpcTask
 
-/// The `NSURLSessionTask` that was used to make the request.
-@property (nonatomic, readonly) NSURLSessionDataTask *dataTask;
-
-/// The session that was used to make to the request.
-@property (nonatomic, readonly) NSURLSession *session;
-
-/// The delegate used manage handler code.
-@property (nonatomic, readonly) DBDelegate *delegate;
-
 ///
 /// `DBRpcTaskImpl` full constructor.
 ///
-/// @param task The `NSURLSessionDataTask` task that initialized the network request.
+/// @param task The `DBURLSessionTask` task that initialized the network request.
 /// @param tokenUid Identifies a unique Dropbox account. Used for the multi Dropbox account case where client objects
 /// are each associated with a particular Dropbox account.
-/// @param session The `NSURLSession` used to make the network request.
-/// @param delegate The delegate that manages and executes response code.
 /// @param route The static `DBRoute` instance associated with the route to which the request was made. Contains
 /// information like route host, response type, etc.). This is used in the deserialization process.
 ///
 /// @return An initialized instance.
 ///
-- (instancetype)initWithTask:(NSURLSessionDataTask *)task
+- (instancetype)initWithTask:(id<DBURLSessionTask>)task
                     tokenUid:(nullable NSString *)tokenUid
-                     session:(NSURLSession *)session
-                    delegate:(DBDelegate *)delegate
                        route:(DBRoute *)route;
 @end
 
@@ -52,57 +40,31 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface DBUploadTaskImpl : DBUploadTask
 
-/// The `NSURLSessionTask` that was used to make the request.
-@property (nonatomic, readonly) NSURLSessionUploadTask *uploadTask;
-
 /// The session that was used to make to the request.
 @property (nonatomic, readonly) NSURLSession *session;
-
-/// The delegate used manage handler code.
-@property (nonatomic, readonly) DBDelegate *delegate;
-
-/// The url to upload.
-@property (nonatomic, readonly, nullable) NSURL *inputUrl;
-
-/// The data to upload.
-@property (nonatomic, readonly, nullable) NSData *inputData;
 
 ///
 /// `DBUploadTask` full constructor.
 ///
-/// @param task The `NSURLSessionDataTask` task that initialized the network request.
+/// @param task The `DBURLSessionTask` task that initialized the network request.
 /// @param tokenUid Identifies a unique Dropbox account. Used for the multi Dropbox account case where client objects
 /// are each associated with a particular Dropbox account.
-/// @param session The `NSURLSession` used to make the network request.
-/// @param delegate The delegate that manages and executes response code.
 /// @param route The static `DBRoute` instance associated with the route to which the request was made. Contains
 /// information like route host, response type, etc.). This is used in the deserialization process.
-/// @param inputUrl The url to upload.
-/// @param inputData The data to upload.
 ///
 /// @return An initialized instance.
 ///
-- (instancetype)initWithTask:(NSURLSessionUploadTask *)task
+- (instancetype)initWithTask:(id<DBURLSessionTask>)task
                     tokenUid:(nullable NSString *)tokenUid
-                     session:(NSURLSession *)session
-                    delegate:(DBDelegate *)delegate
-                       route:(DBRoute *)route
-                    inputUrl:(nullable NSURL *)inputUrl
-                   inputData:(nullable NSData *)inputData;
+                       route:(DBRoute *)route;
 @end
 
 #pragma mark - Download-style network task (NSURL)
 
 @interface DBDownloadUrlTaskImpl : DBDownloadUrlTask
 
-/// The `NSURLSessionTask` that was used to make the request.
-@property (nonatomic, readonly) NSURLSessionDownloadTask *downloadUrlTask;
-
 /// The session that was used to make to the request.
 @property (nonatomic, readonly) NSURLSession *session;
-
-/// The delegate used manage handler code.
-@property (nonatomic, readonly) DBDelegate *delegate;
 
 ///
 /// `DBDownloadUrlTask` full constructor.
@@ -110,8 +72,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param task The `NSURLSessionDataTask` task that initialized the network request.
 /// @param tokenUid Identifies a unique Dropbox account. Used for the multi Dropbox account case where client objects
 /// are each associated with a particular Dropbox account.
-/// @param session The `NSURLSession` used to make the network request.
-/// @param delegate The delegate that manages and executes response code.
 /// @param route The static `DBRoute` instance associated with the route to which the request was made. Contains
 /// information like route host, response type, etc.). This is used in the deserialization process.
 /// @param overwrite Whether the outputted file should overwrite in the event of a name collision.
@@ -119,10 +79,8 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// @return An initialized instance.
 ///
-- (instancetype)initWithTask:(NSURLSessionDownloadTask *)task
+- (instancetype)initWithTask:(id<DBURLSessionTask>)task
                     tokenUid:(nullable NSString *)tokenUid
-                     session:(NSURLSession *)session
-                    delegate:(DBDelegate *)delegate
                        route:(DBRoute *)route
                    overwrite:(BOOL)overwrite
                  destination:(NSURL *)destination;
@@ -132,14 +90,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface DBDownloadDataTaskImpl : DBDownloadDataTask
 
-/// The `NSURLSessionTask` that was used to make the request.
-@property (nonatomic, readonly) NSURLSessionDownloadTask *downloadDataTask;
-
 /// The session that was used to make to the request.
 @property (nonatomic, readonly) NSURLSession *session;
-
-/// The delegate used manage handler code.
-@property (nonatomic, readonly) DBDelegate *delegate;
 
 ///
 /// DBDownloadDataTask full constructor.
@@ -147,17 +99,13 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param task The `NSURLSessionDataTask` task that initialized the network request.
 /// @param tokenUid Identifies a unique Dropbox account. Used for the multi Dropbox account case where client objects
 /// are each associated with a particular Dropbox account.
-/// @param session The `NSURLSession` used to make the network request.
-/// @param delegate The delegate that manages and executes response code.
 /// @param route The static `DBRoute` instance associated with the route to which the request was made. Contains
 /// information like route host, response type, etc.). This is used in the deserialization process.
 ///
 /// @return An initialized instance.
 ///
-- (instancetype)initWithTask:(NSURLSessionDownloadTask *)task
+- (instancetype)initWithTask:(id<DBURLSessionTask>)task
                     tokenUid:(nullable NSString *)tokenUid
-                     session:(NSURLSession *)session
-                    delegate:(DBDelegate *)delegate
                        route:(DBRoute *)route;
 @end
 

--- a/Source/ObjectiveDropboxOfficial/Headers/Internal/Networking/DBURLSessionTaskWithTokenRefresh.h
+++ b/Source/ObjectiveDropboxOfficial/Headers/Internal/Networking/DBURLSessionTaskWithTokenRefresh.h
@@ -1,0 +1,84 @@
+///
+/// Copyright (c) 2020 Dropbox, Inc. All rights reserved.
+///
+
+#import <Foundation/Foundation.h>
+#import "DBHandlerTypes.h"
+#import "DBHandlerTypesInternal.h"
+#import "DBTasks.h"
+
+@protocol DBAccessTokenProvider;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Response handler for DBURLSessionTask.
+@interface DBURLSessionTaskResponseBlockWrapper: NSObject
+
+/// Handler wrapper for RPC tasks.
++ (DBURLSessionTaskResponseBlockWrapper *)withRpcResponseBlock:(DBRpcResponseBlockStorage)responseBlock;
+/// Handler wrapper for upload tasks.
++ (DBURLSessionTaskResponseBlockWrapper *)withUploadResponseBlock:(DBUploadResponseBlockStorage)responseBlock;
+/// Handler wrapper for download tasks.
++ (DBURLSessionTaskResponseBlockWrapper *)withDownloadResponseBlock:(DBDownloadResponseBlockStorage)responseBlock;
+
+@end
+
+/// Protocol for custom URLSession tasks that are used internally by the DBTask classes.
+@protocol DBURLSessionTask <NSObject>
+
+typedef void (^DBURLSessionTaskSetupBlock)(NSUInteger taskIdentifier);
+
+/// The `NSURLSession` used to make the network request.
+@property (nonatomic, readonly) NSURLSession *session;
+
+/// Creates a new instance with same initial setup.
+- (id<DBURLSessionTask>)duplicate;
+
+/// Cancels the API request.
+- (void)cancel;
+
+/// Suspends the API request.
+- (void)suspend;
+
+/// Resumes the API request.
+- (void)resume;
+
+/// Sets progress handler for the task.
+/// @param progressBlock The `DBProgressBlock` that handles task progress.
+/// @param queue An optional operation queue on which to execute progress handler code. If not provided, the handler
+/// may be executed on any queue.
+- (void)setProgressBlock:(DBProgressBlock)progressBlock queue:(nullable NSOperationQueue *)queue;
+
+/// Sets response/completion handler for the task.
+/// @param responseBlock The `DBURLSessionTaskResponseBlock` that handles task response.
+/// @param queue An optional operation queue on which to execute response handler code. If not provided, the handler
+/// may be executed on any queue.
+- (void)setResponseBlock:(DBURLSessionTaskResponseBlockWrapper *)responseBlock
+                   queue:(nullable NSOperationQueue *)queue;
+
+@end
+
+/// Block that creates the actual API request.
+typedef NSURLSessionTask *_Nonnull(^DBURLSessionTaskCreationBlock)(void);
+
+/// A class that wraps a network request that calls Dropbox API.
+/// This class will first attempt to refresh the access token and conditionally proceed to the actual API call.
+@interface DBURLSessionTaskWithTokenRefresh : NSObject<DBURLSessionTask>
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/// Designated Initializer.
+///
+/// @param taskCreationBlock The block that creates the actual API request.
+/// @param taskDelegate The delegate used manage request handler code.
+/// @param urlSession The `NSURLSession` used to make the API network request.
+/// @param tokenProvider The `DBAccessTokenProvider` object to perform token refresh.
+///
+- (instancetype)initWithTaskCreationBlock:(DBURLSessionTaskCreationBlock)taskCreationBlock
+                             taskDelegate:(nullable DBDelegate *)taskDelegate
+                               urlSession:(NSURLSession *)urlSession
+                            tokenProvider:(id<DBAccessTokenProvider>)tokenProvider NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/ObjectiveDropboxOfficial/ObjectiveDropboxOfficial.xcodeproj/project.pbxproj
+++ b/Source/ObjectiveDropboxOfficial/ObjectiveDropboxOfficial.xcodeproj/project.pbxproj
@@ -40,6 +40,10 @@
 		BF474D39248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = BF474D36248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.h */; };
 		BF474D3A248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = BF474D37248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.m */; };
 		BF474D3B248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = BF474D37248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.m */; };
+		BF6162C52491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.h in Headers */ = {isa = PBXBuildFile; fileRef = BF6162C32491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.h */; };
+		BF6162C62491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.h in Headers */ = {isa = PBXBuildFile; fileRef = BF6162C32491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.h */; };
+		BF6162C72491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.m in Sources */ = {isa = PBXBuildFile; fileRef = BF6162C42491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.m */; };
+		BF6162C82491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.m in Sources */ = {isa = PBXBuildFile; fileRef = BF6162C42491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.m */; };
 		BF7E352B2488562F00DEDF84 /* DBLoadingViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = BF7E35292488562F00DEDF84 /* DBLoadingViewController.h */; };
 		BF7E352C2488562F00DEDF84 /* DBLoadingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BF7E352A2488562F00DEDF84 /* DBLoadingViewController.m */; };
 		BF7E352E248858B600DEDF84 /* DBLoadingStatusDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = BF7E352D248858B600DEDF84 /* DBLoadingStatusDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -3950,6 +3954,8 @@
 		BF33F93D24874DED001F4072 /* DBOAuthTokenRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DBOAuthTokenRequest.m; sourceTree = "<group>"; };
 		BF474D36248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DBAccessToken+NSSecureCoding.h"; sourceTree = "<group>"; };
 		BF474D37248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "DBAccessToken+NSSecureCoding.m"; sourceTree = "<group>"; };
+		BF6162C32491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DBURLSessionTaskWithTokenRefresh.h; sourceTree = "<group>"; };
+		BF6162C42491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DBURLSessionTaskWithTokenRefresh.m; sourceTree = "<group>"; };
 		BF7E35292488562F00DEDF84 /* DBLoadingViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DBLoadingViewController.h; sourceTree = "<group>"; };
 		BF7E352A2488562F00DEDF84 /* DBLoadingViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DBLoadingViewController.m; sourceTree = "<group>"; };
 		BF7E352D248858B600DEDF84 /* DBLoadingStatusDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DBLoadingStatusDelegate.h; sourceTree = "<group>"; };
@@ -8323,6 +8329,7 @@
 				F29781881E03692800876A73 /* DBTransportDefaultClient.m */,
 				F24169451E523FD30038E306 /* DBTransportDefaultConfig.h */,
 				F24169461E523FEB0038E306 /* DBTransportDefaultConfig.m */,
+				BF6162C42491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.m */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -8382,6 +8389,7 @@
 		F2A2CE761E562817001D8449 /* Networking */ = {
 			isa = PBXGroup;
 			children = (
+				BF6162C32491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.h */,
 				F2A2CE771E562817001D8449 /* DBDelegate.h */,
 				F2A2CE781E562817001D8449 /* DBHandlerTypesInternal.h */,
 				F2A2CE791E562817001D8449 /* DBSDKReachability.h */,
@@ -9492,6 +9500,7 @@
 				C43D568D245748CB008DF48C /* DBTEAMLOGTeamFolderDowngradeDetails.h in Headers */,
 				C43D54A7245748C7008DF48C /* DBTEAMLOGSecondaryTeamRequestExpiredDetails.h in Headers */,
 				C43D5321245748C4008DF48C /* DBFILEPROPERTIESRemovePropertiesError.h in Headers */,
+				BF6162C52491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.h in Headers */,
 				C43D508B245748BF008DF48C /* DBFILEREQUESTSDeleteFileRequestArgs.h in Headers */,
 				C43D5A35245748D3008DF48C /* DBTEAMLOGDeviceChangeIpWebType.h in Headers */,
 				C43D598B245748D1008DF48C /* DBTEAMLOGWebSessionsChangeActiveSessionLimitDetails.h in Headers */,
@@ -11768,6 +11777,7 @@
 				C43D5B44245748D5008DF48C /* DBFILESLookupError.h in Headers */,
 				C43D592A245748D1008DF48C /* DBTEAMLOGGroupRemoveExternalIdDetails.h in Headers */,
 				C43D4F80245748BD008DF48C /* DBSHARINGSharedFolderMetadataBase.h in Headers */,
+				BF6162C62491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.h in Headers */,
 				C43D526E245748C3008DF48C /* DBTEAMTeamFolderRenameArg.h in Headers */,
 				C43D4F3E245748BC008DF48C /* DBSHARINGListFilesContinueError.h in Headers */,
 				C43D51AA245748C1008DF48C /* DBTEAMIncludeMembersArg.h in Headers */,
@@ -12334,6 +12344,7 @@
 				C43D5D03245748D9008DF48C /* DBTEAMTeamAuthRoutes.m in Sources */,
 				3C3C29741F7D757E00C54011 /* DBTransportBaseHostnameConfig.m in Sources */,
 				C43D5CE7245748D9008DF48C /* DBFILESRouteObjects.m in Sources */,
+				BF6162C72491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.m in Sources */,
 				C43D4F11245748BC008DF48C /* DBSecondaryEmailsObjects.m in Sources */,
 				C43D5CF1245748D9008DF48C /* DBCLOUDDOCSRouteObjects.m in Sources */,
 				C43D50BB245748BF008DF48C /* DBTeamCommonObjects.m in Sources */,
@@ -12440,6 +12451,7 @@
 				BF33F92B24873F12001F4072 /* DBOAuthConstants.m in Sources */,
 				C43D506A245748BF008DF48C /* DBFileRequestsObjects.m in Sources */,
 				F2A2CE9B1E562E46001D8449 /* DBCustomTasks.m in Sources */,
+				BF6162C82491A29F004E34B7 /* DBURLSessionTaskWithTokenRefresh.m in Sources */,
 				C43D4E6A245748BB008DF48C /* DBStoneBase.m in Sources */,
 				C43D5CCC245748D9008DF48C /* DBPAPERRouteObjects.m in Sources */,
 				BF474D3B248ED1AA007171C0 /* DBAccessToken+NSSecureCoding.m in Sources */,

--- a/Source/ObjectiveDropboxOfficial/Shared/Generated/Client/DBUserBaseClient.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Generated/Client/DBUserBaseClient.h
@@ -67,6 +67,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// Routes within the `users` namespace.
 @property (nonatomic, readonly) DBUSERSUserAuthRoutes *usersRoutes;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Initializes the `DBUserBaseClient` object with a networking client.
 - (instancetype)initWithTransportClient:(id<DBTransportClient>)client NS_DESIGNATED_INITIALIZER;
 

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBDelegate.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBDelegate.m
@@ -203,12 +203,12 @@
   return tmpOutputPath;
 }
 
-- (void)addProgressHandler:(NSURLSessionTask *)task
-                   session:(NSURLSession *)session
-           progressHandler:(void (^)(int64_t, int64_t, int64_t))handler
-      progressHandlerQueue:(NSOperationQueue *)handlerQueue {
+- (void)addProgressHandlerForTaskWithIdentifier:(NSUInteger)identifier
+                                        session:(NSURLSession *)session
+                                progressHandler:(void (^)(int64_t, int64_t, int64_t))handler
+                           progressHandlerQueue:(NSOperationQueue *)handlerQueue {
   [_delegateQueue addOperationWithBlock:^{
-    NSNumber *taskId = @(task.taskIdentifier);
+    NSNumber *taskId = @(identifier);
 
     DBSessionData *sessionData = [self sessionDataWithSession:session];
     DBProgressData *progressData = sessionData.progressData[taskId];
@@ -230,12 +230,12 @@
 
 #pragma mark - Add RPC-style handler
 
-- (void)addRpcResponseHandler:(NSURLSessionTask *)task
-                      session:(NSURLSession *)session
-              responseHandler:(DBRpcResponseBlockStorage)handler
-         responseHandlerQueue:(NSOperationQueue *)handlerQueue {
+- (void)addRpcResponseHandlerForTaskWithIdentifier:(NSUInteger)identifier
+                                           session:(NSURLSession *)session
+                                   responseHandler:(DBRpcResponseBlockStorage)handler
+                              responseHandlerQueue:(NSOperationQueue *)handlerQueue {
   [_delegateQueue addOperationWithBlock:^{
-    NSNumber *taskId = @(task.taskIdentifier);
+    NSNumber *taskId = @(identifier);
     DBSessionData *sessionData = [self sessionDataWithSession:session];
 
     DBCompletionData *completionData = sessionData.completionData[taskId];
@@ -262,12 +262,12 @@
 
 #pragma mark - Add Upload-style handler
 
-- (void)addUploadResponseHandler:(NSURLSessionTask *)task
-                         session:(NSURLSession *)session
-                 responseHandler:(DBUploadResponseBlockStorage)handler
-            responseHandlerQueue:(NSOperationQueue *)handlerQueue {
+- (void)addUploadResponseHandlerForTaskWithIdentifier:(NSUInteger)identifier
+                                              session:(NSURLSession *)session
+                                      responseHandler:(DBUploadResponseBlockStorage)handler
+                                 responseHandlerQueue:(NSOperationQueue *)handlerQueue {
   [_delegateQueue addOperationWithBlock:^{
-    NSNumber *taskId = @(task.taskIdentifier);
+    NSNumber *taskId = @(identifier);
     DBSessionData *sessionData = [self sessionDataWithSession:session];
 
     DBCompletionData *completionData = sessionData.completionData[taskId];
@@ -294,12 +294,12 @@
 
 #pragma mark - Add Download-style handler
 
-- (void)addDownloadResponseHandler:(NSURLSessionTask *)task
-                           session:(NSURLSession *)session
-                   responseHandler:(DBDownloadResponseBlockStorage)handler
-              responseHandlerQueue:(NSOperationQueue *)handlerQueue {
+- (void)addDownloadResponseHandlerForTaskWithIdentifier:(NSUInteger)identifier
+                                                session:(NSURLSession *)session
+                                        responseHandler:(DBDownloadResponseBlockStorage)handler
+                                   responseHandlerQueue:(NSOperationQueue *)handlerQueue {
   [_delegateQueue addOperationWithBlock:^{
-    NSNumber *taskId = @(task.taskIdentifier);
+    NSNumber *taskId = @(identifier);
     DBSessionData *sessionData = [self sessionDataWithSession:session];
 
     DBCompletionData *completionData = sessionData.completionData[taskId];

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasks.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasks.h
@@ -35,6 +35,9 @@ NS_ASSUME_NONNULL_BEGIN
   NSOperationQueue *_queue;
 }
 
+/// A unique string identifier for this task.
+@property (nonatomic, readonly, copy) NSString *taskIdentifier;
+
 /// Tracks the number of times this task has been retried.
 @property (nonatomic) int retryCount;
 

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasks.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasks.m
@@ -21,6 +21,7 @@
     _route = route;
     _queue = nil;
     _tokenUid = [tokenUid copy];
+    _taskIdentifier = [[NSUUID UUID].UUIDString copy];
   }
   return self;
 }

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasksImpl.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasksImpl.m
@@ -15,37 +15,34 @@
 @implementation DBRpcTaskImpl {
   DBRpcTaskImpl *_selfRetained;
   DBRpcResponseBlockImpl _responseBlock;
+  id<DBURLSessionTask> _task;
 }
 
-- (instancetype)initWithTask:(NSURLSessionDataTask *)task
+- (instancetype)initWithTask:(id<DBURLSessionTask>)task
                     tokenUid:(NSString *)tokenUid
-                     session:(NSURLSession *)session
-                    delegate:(DBDelegate *)delegate
                        route:(DBRoute *)route {
   self = [super initWithRoute:route tokenUid:tokenUid];
   if (self) {
-    _dataTask = task;
-    _session = session;
-    _delegate = delegate;
+    _task = task;
     _selfRetained = self;
   }
   return self;
 }
 
 - (void)cancel {
-  [_dataTask cancel];
+  [_task cancel];
 }
 
 - (void)suspend {
-  [_dataTask suspend];
+  [_task suspend];
 }
 
 - (void)resume {
-  [_dataTask resume];
+  [_task resume];
 }
 
 - (void)start {
-  [_dataTask resume];
+  [_task resume];
 }
 
 - (void)cleanup {
@@ -58,14 +55,10 @@
 }
 
 - (DBTask *)restart {
-  NSURLRequest *request = [_dataTask.originalRequest copy];
-  NSURLSessionDataTask *task = [_session dataTaskWithRequest:request];
-  DBRpcTaskImpl *sdkTask =
-      [[DBRpcTaskImpl alloc] initWithTask:task tokenUid:self.tokenUid session:_session delegate:_delegate route:_route];
+  DBRpcTaskImpl *sdkTask = [[DBRpcTaskImpl alloc] initWithTask:[_task duplicate] tokenUid:self.tokenUid route:_route];
   sdkTask.retryCount += 1;
   [sdkTask setResponseBlock:_responseBlock queue:_queue];
-  [task resume];
-
+  [sdkTask resume];
   return sdkTask;
 }
 
@@ -79,7 +72,7 @@
                                                                   cleanupBlock:^{
                                                                     [self cleanup];
                                                                   }];
-  [_delegate addRpcResponseHandler:_dataTask session:_session responseHandler:storageBlock responseHandlerQueue:queue];
+  [_task setResponseBlock:[DBURLSessionTaskResponseBlockWrapper withRpcResponseBlock:storageBlock] queue:queue];
   return self;
 }
 
@@ -88,7 +81,7 @@
 }
 
 - (DBRpcTask *)setProgressBlock:(DBProgressBlock)progressBlock queue:(NSOperationQueue *)queue {
-  [_delegate addProgressHandler:_dataTask session:_session progressHandler:progressBlock progressHandlerQueue:queue];
+  [_task setProgressBlock:progressBlock queue:queue];
   return self;
 }
 
@@ -99,24 +92,21 @@
 @implementation DBUploadTaskImpl {
   DBUploadTaskImpl *_selfRetained;
   DBUploadResponseBlockImpl _responseBlock;
+  id<DBURLSessionTask> _uploadTask;
 }
 
-- (instancetype)initWithTask:(NSURLSessionUploadTask *)task
+- (instancetype)initWithTask:(id<DBURLSessionTask>)task
                     tokenUid:(NSString *)tokenUid
-                     session:(NSURLSession *)session
-                    delegate:(DBDelegate *)delegate
-                       route:(DBRoute *)route
-                    inputUrl:(NSURL *)inputUrl
-                   inputData:(NSData *)inputData {
+                       route:(DBRoute *)route {
   self = [super initWithRoute:route tokenUid:tokenUid];
   if (self) {
     _uploadTask = task;
-    _session = session;
-    _delegate = delegate;
-    _inputUrl = inputUrl;
-    _inputData = inputData;
   }
   return self;
+}
+
+- (NSURLSession *)session {
+  return _uploadTask.session;
 }
 
 - (void)cancel {
@@ -145,28 +135,12 @@
 }
 
 - (DBTask *)restart {
-  NSURLRequest *request = [_uploadTask.originalRequest copy];
-  NSURLSessionUploadTask *task = nil;
-  self.retryCount += 1;
-  if (_inputUrl) {
-    task = [_session uploadTaskWithRequest:request fromFile:self->_inputUrl];
-  } else if (_inputData) {
-    task = [_session uploadTaskWithRequest:request fromData:self->_inputData];
-  } else {
-    task = [_session uploadTaskWithStreamedRequest:request];
-  }
-
-  DBUploadTaskImpl *sdkTask = [[DBUploadTaskImpl alloc] initWithTask:task
+  DBUploadTaskImpl *sdkTask = [[DBUploadTaskImpl alloc] initWithTask:[_uploadTask duplicate]
                                                             tokenUid:self.tokenUid
-                                                             session:_session
-                                                            delegate:_delegate
-                                                               route:_route
-                                                            inputUrl:_inputUrl
-                                                           inputData:_inputData];
+                                                               route:_route];
   sdkTask.retryCount += 1;
   [sdkTask setResponseBlock:_responseBlock queue:_queue];
   [sdkTask resume];
-
   return sdkTask;
 }
 
@@ -180,11 +154,8 @@
                                                                      cleanupBlock:^{
                                                                        [self cleanup];
                                                                      }];
-  [_delegate addUploadResponseHandler:_uploadTask
-                              session:_session
-                      responseHandler:storageBlock
-                 responseHandlerQueue:queue];
-
+  [_uploadTask setResponseBlock:[DBURLSessionTaskResponseBlockWrapper withUploadResponseBlock:storageBlock]
+                          queue:queue];
   return self;
 }
 
@@ -193,7 +164,7 @@
 }
 
 - (DBUploadTask *)setProgressBlock:(DBProgressBlock)progressBlock queue:(NSOperationQueue *)queue {
-  [_delegate addProgressHandler:_uploadTask session:_session progressHandler:progressBlock progressHandlerQueue:queue];
+  [_uploadTask setProgressBlock:progressBlock queue:queue];
   return self;
 }
 
@@ -204,25 +175,27 @@
 @implementation DBDownloadUrlTaskImpl {
   DBDownloadUrlTaskImpl *_selfRetained;
   DBDownloadUrlResponseBlockImpl _responseBlock;
+  id<DBURLSessionTask> _downloadUrlTask;
 }
 
-- (instancetype)initWithTask:(NSURLSessionDownloadTask *)task
+- (instancetype)initWithTask:(id<DBURLSessionTask>)task
                     tokenUid:(NSString *)tokenUid
-                     session:(NSURLSession *)session
-                    delegate:(DBDelegate *)delegate
                        route:(DBRoute *)route
                    overwrite:(BOOL)overwrite
                  destination:(NSURL *)destination {
   self = [super initWithRoute:route tokenUid:tokenUid];
   if (self) {
     _downloadUrlTask = task;
-    _session = session;
-    _delegate = delegate;
     _overwrite = overwrite;
     _destination = destination;
   }
   return self;
 }
+
+- (NSURLSession *)session {
+  return _downloadUrlTask.session;
+}
+
 
 - (void)cancel {
   [_downloadUrlTask cancel];
@@ -250,19 +223,14 @@
 }
 
 - (DBTask *)restart {
-  NSURLRequest *request = [_downloadUrlTask.originalRequest copy];
-  NSURLSessionDownloadTask *task = [_session downloadTaskWithRequest:request];
-  DBDownloadUrlTaskImpl *sdkTask = [[DBDownloadUrlTaskImpl alloc] initWithTask:task
+  DBDownloadUrlTaskImpl *sdkTask = [[DBDownloadUrlTaskImpl alloc] initWithTask:[_downloadUrlTask duplicate]
                                                                       tokenUid:self.tokenUid
-                                                                       session:_session
-                                                                      delegate:_delegate
                                                                          route:_route
                                                                      overwrite:_overwrite
                                                                    destination:_destination];
   sdkTask.retryCount += 1;
   [sdkTask setResponseBlock:_responseBlock queue:_queue];
-  [task resume];
-
+  [sdkTask resume];
   return sdkTask;
 }
 
@@ -276,11 +244,9 @@
                                                                        cleanupBlock:^{
                                                                          [self cleanup];
                                                                        }];
-  [_delegate addDownloadResponseHandler:_downloadUrlTask
-                                session:_session
-                        responseHandler:storageBlock
-                   responseHandlerQueue:queue];
 
+  [_downloadUrlTask setResponseBlock:[DBURLSessionTaskResponseBlockWrapper withDownloadResponseBlock:storageBlock]
+                               queue:queue];
   return self;
 }
 
@@ -289,10 +255,7 @@
 }
 
 - (DBDownloadUrlTask *)setProgressBlock:(DBProgressBlock)progressBlock queue:(NSOperationQueue *)queue {
-  [_delegate addProgressHandler:_downloadUrlTask
-                        session:_session
-                progressHandler:progressBlock
-           progressHandlerQueue:queue];
+  [_downloadUrlTask setProgressBlock:progressBlock queue:queue];
   return self;
 }
 
@@ -303,20 +266,21 @@
 @implementation DBDownloadDataTaskImpl {
   DBDownloadDataTaskImpl *_selfRetained;
   DBDownloadDataResponseBlockImpl _responseBlock;
+  id<DBURLSessionTask> _downloadDataTask;
 }
 
-- (instancetype)initWithTask:(NSURLSessionDownloadTask *)task
+- (instancetype)initWithTask:(id<DBURLSessionTask>)task
                     tokenUid:(NSString *)tokenUid
-                     session:(NSURLSession *)session
-                    delegate:(DBDelegate *)delegate
                        route:(DBRoute *)route {
   self = [super initWithRoute:route tokenUid:tokenUid];
   if (self) {
     _downloadDataTask = task;
-    _session = session;
-    _delegate = delegate;
   }
   return self;
+}
+
+- (NSURLSession *)session {
+  return _downloadDataTask.session;
 }
 
 - (void)cancel {
@@ -345,17 +309,12 @@
 }
 
 - (DBTask *)restart {
-  NSURLRequest *request = [_downloadDataTask.originalRequest copy];
-  NSURLSessionDownloadTask *task = [_session downloadTaskWithRequest:request];
-  DBDownloadDataTaskImpl *sdkTask = [[DBDownloadDataTaskImpl alloc] initWithTask:task
+  DBDownloadDataTaskImpl *sdkTask = [[DBDownloadDataTaskImpl alloc] initWithTask:[_downloadDataTask duplicate]
                                                                         tokenUid:self.tokenUid
-                                                                         session:_session
-                                                                        delegate:_delegate
                                                                            route:_route];
   sdkTask.retryCount += 1;
   [sdkTask setResponseBlock:_responseBlock queue:_queue];
-  [task resume];
-
+  [sdkTask resume];
   return sdkTask;
 }
 
@@ -370,11 +329,8 @@
                                                                        cleanupBlock:^{
                                                                          [self cleanup];
                                                                        }];
-  [_delegate addDownloadResponseHandler:_downloadDataTask
-                                session:_session
-                        responseHandler:storageBlock
-                   responseHandlerQueue:queue];
-
+  [_downloadDataTask setResponseBlock:[DBURLSessionTaskResponseBlockWrapper withDownloadResponseBlock:storageBlock]
+                                queue:queue];
   return self;
 }
 
@@ -383,10 +339,7 @@
 }
 
 - (DBDownloadDataTask *)setProgressBlock:(DBProgressBlock)progressBlock queue:(NSOperationQueue *)queue {
-  [_delegate addProgressHandler:_downloadDataTask
-                        session:_session
-                progressHandler:progressBlock
-           progressHandlerQueue:queue];
+  [_downloadDataTask setProgressBlock:progressBlock queue:queue];
   return self;
 }
 

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasksStorage.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasksStorage.m
@@ -55,7 +55,7 @@
   @synchronized(self) {
     if (!_cancel) {
       NSString *sessionId = task.session.configuration.identifier ?: kDBSDKForegroundSessionId;
-      NSString *key = [NSString stringWithFormat:@"%@/%lu", sessionId, (unsigned long)task.uploadTask.taskIdentifier];
+      NSString *key = [NSString stringWithFormat:@"%@/%@", sessionId, task.taskIdentifier];
       [_uploadTasks setObject:task forKey:key];
     } else {
       [task cancel];
@@ -66,7 +66,7 @@
 - (void)removeUploadTask:(DBUploadTaskImpl *)task {
   @synchronized(self) {
     NSString *sessionId = task.session.configuration.identifier ?: kDBSDKForegroundSessionId;
-    NSString *key = [NSString stringWithFormat:@"%@/%lu", sessionId, (unsigned long)task.uploadTask.taskIdentifier];
+    NSString *key = [NSString stringWithFormat:@"%@/%@", sessionId, task.taskIdentifier];
     [_uploadTasks removeObjectForKey:key];
   }
 }
@@ -76,7 +76,7 @@
     if (!_cancel) {
       NSString *sessionId = task.session.configuration.identifier ?: kDBSDKForegroundSessionId;
       NSString *key =
-          [NSString stringWithFormat:@"%@/%lu", sessionId, (unsigned long)task.downloadUrlTask.taskIdentifier];
+          [NSString stringWithFormat:@"%@/%@", sessionId, task.taskIdentifier];
       [_downloadUrlTasks setObject:task forKey:key];
     } else {
       [task cancel];
@@ -88,7 +88,7 @@
   @synchronized(self) {
     NSString *sessionId = task.session.configuration.identifier ?: kDBSDKForegroundSessionId;
     NSString *key =
-        [NSString stringWithFormat:@"%@/%lu", sessionId, (unsigned long)task.downloadUrlTask.taskIdentifier];
+        [NSString stringWithFormat:@"%@/%@", sessionId, task.taskIdentifier];
     [_downloadUrlTasks removeObjectForKey:key];
   }
 }
@@ -98,7 +98,7 @@
     if (!_cancel) {
       NSString *sessionId = task.session.configuration.identifier ?: kDBSDKForegroundSessionId;
       NSString *key =
-          [NSString stringWithFormat:@"%@/%lu", sessionId, (unsigned long)task.downloadDataTask.taskIdentifier];
+          [NSString stringWithFormat:@"%@/%@", sessionId, task.taskIdentifier];
       [_downloadDataTasks setObject:task forKey:key];
     } else {
       [task cancel];
@@ -110,7 +110,7 @@
   @synchronized(self) {
     NSString *sessionId = task.session.configuration.identifier ?: kDBSDKForegroundSessionId;
     NSString *key =
-        [NSString stringWithFormat:@"%@/%lu", sessionId, (unsigned long)task.downloadDataTask.taskIdentifier];
+        [NSString stringWithFormat:@"%@/%@", sessionId, task.taskIdentifier];
     [_downloadDataTasks removeObjectForKey:key];
   }
 }

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBURLSessionTaskWithTokenRefresh.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBURLSessionTaskWithTokenRefresh.m
@@ -1,0 +1,222 @@
+///
+/// Copyright (c) 2020 Dropbox, Inc. All rights reserved.
+///
+
+#import "DBURLSessionTaskWithTokenRefresh.h"
+
+#import "DBAccessTokenProvider.h"
+#import "DBOAuthResult.h"
+#import "DBDelegate.h"
+
+@interface DBURLSessionTaskResponseBlockWrapper ()
+
+@property (nonatomic, strong, nullable) DBRpcResponseBlockStorage rpcResponseBlock;
+@property (nonatomic, strong, nullable) DBUploadResponseBlockStorage uploadResponseBlock;
+@property (nonatomic, strong, nullable) DBDownloadResponseBlockStorage downloadResponseBlock;
+
+@end
+
+@implementation DBURLSessionTaskResponseBlockWrapper
+
++ (DBURLSessionTaskResponseBlockWrapper *)withRpcResponseBlock:(DBRpcResponseBlockStorage)responseBlock {
+  DBURLSessionTaskResponseBlockWrapper *wrapper = [[DBURLSessionTaskResponseBlockWrapper alloc] init];
+  wrapper.rpcResponseBlock = responseBlock;
+  return wrapper;
+}
+
++ (DBURLSessionTaskResponseBlockWrapper *)withUploadResponseBlock:(DBUploadResponseBlockStorage)responseBlock {
+  DBURLSessionTaskResponseBlockWrapper *wrapper = [[DBURLSessionTaskResponseBlockWrapper alloc] init];
+  wrapper.uploadResponseBlock = responseBlock;
+  return wrapper;
+}
+
++ (DBURLSessionTaskResponseBlockWrapper *)withDownloadResponseBlock:(DBDownloadResponseBlockStorage)responseBlock {
+  DBURLSessionTaskResponseBlockWrapper *wrapper = [[DBURLSessionTaskResponseBlockWrapper alloc] init];
+  wrapper.downloadResponseBlock = responseBlock;
+  return wrapper;
+}
+
+@end
+
+@interface DBURLSessionTaskWithTokenRefresh ()
+
+@property (nonatomic, weak) DBDelegate *taskDelegate;
+@property (nonatomic, strong) DBURLSessionTaskCreationBlock taskCreationBlock;
+@property (nonatomic, strong) id<DBAccessTokenProvider> tokenProvider;
+@property (nonatomic, strong) DBProgressBlock progressBlock;
+@property (nonatomic, strong) NSOperationQueue *progressQueue;
+@property (nonatomic, strong) DBURLSessionTaskResponseBlockWrapper *responseBlockWrapper;
+@property (nonatomic, strong) NSOperationQueue *responseQueue;
+@property (nonatomic, strong) dispatch_queue_t serialQueue;
+@property (nonatomic, strong, nullable) NSURLSessionTask *sessionTask;
+@property (nonatomic, assign) BOOL cancelled;
+@property (nonatomic, assign) BOOL suspended;
+@property (nonatomic, assign) BOOL started;
+
+@end
+
+@implementation DBURLSessionTaskWithTokenRefresh
+
+@synthesize session = _session;
+
+- (instancetype)initWithTaskCreationBlock:(DBURLSessionTaskCreationBlock)taskCreationBlock
+                             taskDelegate:(DBDelegate *)taskDelegate
+                               urlSession:(NSURLSession *)urlSession
+                            tokenProvider:(id<DBAccessTokenProvider>)tokenProvider {
+  self = [super init];
+  if (self) {
+    _taskCreationBlock = taskCreationBlock;
+    _taskDelegate = taskDelegate;
+    _session = urlSession;
+    _tokenProvider = tokenProvider;
+    dispatch_queue_attr_t qosAttribute =
+      dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INITIATED, 0);
+    _serialQueue =
+      dispatch_queue_create("com.dropbox.dropbox_sdk_obj_c.DBURLSessionTaskWithTokenRefresh.queue", qosAttribute);
+  }
+  return self;
+}
+
+- (id<DBURLSessionTask>)duplicate {
+  return [[DBURLSessionTaskWithTokenRefresh alloc] initWithTaskCreationBlock:_taskCreationBlock
+                                                                taskDelegate:_taskDelegate
+                                                                  urlSession:_session
+                                                               tokenProvider:_tokenProvider];
+}
+
+- (void)cancel {
+  dispatch_async(_serialQueue, ^{
+    self->_cancelled = YES;
+    [self->_sessionTask cancel];
+  });
+}
+
+- (void)suspend {
+  dispatch_async(_serialQueue, ^{
+    self->_suspended = YES;
+    [self->_sessionTask suspend];
+  });
+}
+
+- (void)resume {
+  dispatch_async(_serialQueue, ^{
+    self->_started = YES;
+    if (self->_sessionTask) {
+      [self->_sessionTask resume];
+    } else {
+      [self db_start];
+    }
+  });
+}
+
+- (void)setProgressBlock:(DBProgressBlock)progressBlock
+                   queue:(NSOperationQueue *)queue {
+  dispatch_async(_serialQueue, ^{
+    self->_progressBlock = progressBlock;
+    self->_progressQueue = queue;
+    [self db_setProgressHandlerIfNecessary];
+  });
+}
+
+- (void)setResponseBlock:(DBURLSessionTaskResponseBlockWrapper *)responseBlockWrapper
+                   queue:(NSOperationQueue *)queue {
+  dispatch_async(_serialQueue, ^{
+    self->_responseBlockWrapper = responseBlockWrapper;
+    self->_responseQueue = queue;
+    [self db_setResponseHandlerIfNecessary];
+  });
+}
+
+#pragma mark Private helpers
+
+- (void)db_start {
+  DBOAuthCompletion completion = ^(DBOAuthResult *result) {
+    dispatch_async(self->_serialQueue, ^{
+      [self db_handleTokenRefreshResult:result];
+    });
+  };
+
+  if (_tokenProvider) {
+    [_tokenProvider refreshAccessTokenIfNecessary:completion];
+  } else {
+    completion(nil);
+  }
+}
+
+- (void)db_handleTokenRefreshResult:(DBOAuthResult *)result {
+  if ([result isError] && result.errorType != DBAuthInvalidGrant) {
+    // Refresh failed, due to an error that's not invalid grant, e.g. A refresh request timed out.
+    // Complete request with error immediately, so developers could retry and get access token refreshed.
+    // Otherwise, the API request may proceed with an expired access token which would lead to
+    // a false positive auth error.
+    [self db_completeWithError:result.nsError];
+  } else {
+    // Refresh succeeded or a refresh is not required, i.e. access token is valid, continue request normally.
+    // Or
+    // Refresh failed due to invalid grant, e.g. refresh token revoked by user.
+    // Continue, and the API call would failed with an auth error that developers can handle properly.
+    // e.g. Sign out the user upon auth error.
+    [self db_initializeSessionTask];
+  }
+}
+
+- (void)db_initializeSessionTask {
+  _sessionTask = _taskCreationBlock();
+  [self db_setProgressHandlerIfNecessary];
+  [self db_setResponseHandlerIfNecessary];
+  if (_cancelled) {
+    [_sessionTask cancel];
+  } else if (_suspended) {
+    [_sessionTask suspend];
+  } else if (_started) {
+    [_sessionTask resume];
+  }
+}
+
+- (void)db_setProgressHandlerIfNecessary {
+  if (_sessionTask && _progressBlock) {
+    [_taskDelegate addProgressHandlerForTaskWithIdentifier:_sessionTask.taskIdentifier
+                                                   session:_session
+                                           progressHandler:_progressBlock
+                                      progressHandlerQueue:_progressQueue];
+  }
+}
+
+- (void)db_setResponseHandlerIfNecessary {
+  if (_sessionTask == nil || _responseBlockWrapper == nil) {
+    return;
+  }
+
+  if (_responseBlockWrapper.rpcResponseBlock) {
+    [_taskDelegate addRpcResponseHandlerForTaskWithIdentifier:_sessionTask.taskIdentifier
+                                                      session:_session
+                                              responseHandler:_responseBlockWrapper.rpcResponseBlock
+                                         responseHandlerQueue:_responseQueue];
+  } else if (_responseBlockWrapper.uploadResponseBlock) {
+    [_taskDelegate addUploadResponseHandlerForTaskWithIdentifier:_sessionTask.taskIdentifier
+                                                         session:_session
+                                                 responseHandler:_responseBlockWrapper.uploadResponseBlock
+                                            responseHandlerQueue:_responseQueue];
+  } else if (_responseBlockWrapper.downloadResponseBlock) {
+    [_taskDelegate addDownloadResponseHandlerForTaskWithIdentifier:_sessionTask.taskIdentifier
+                                                           session:_session
+                                                   responseHandler:_responseBlockWrapper.downloadResponseBlock
+                                              responseHandlerQueue:_responseQueue];
+  }
+}
+
+- (void)db_completeWithError:(NSError *)error {
+  NSOperationQueue *queue = _responseQueue ?: [NSOperationQueue mainQueue];
+  DBURLSessionTaskResponseBlockWrapper *blockWrapper = _responseBlockWrapper;
+  [queue addOperationWithBlock:^{
+    if (blockWrapper.rpcResponseBlock) {
+      blockWrapper.rpcResponseBlock(nil, nil, error);
+    } else if (blockWrapper.uploadResponseBlock) {
+      blockWrapper.uploadResponseBlock(nil, nil, error);
+    } else if (blockWrapper.downloadResponseBlock) {
+      blockWrapper.downloadResponseBlock(nil, nil, error);
+    }
+  }];
+}
+
+@end

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthResult.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthResult.h
@@ -94,6 +94,10 @@ typedef NS_ENUM(NSInteger, DBOAuthErrorType) {
 /// @note Ensure the `isError` method returns true before accessing, otherwise a runtime exception will be raised.
 @property (nonatomic, readonly, copy) NSString *errorDescription;
 
+/// The `NSError` form of the error result.
+/// @note Ensure the `isError` method returns true before accessing, otherwise a runtime exception will be raised.
+@property (nonatomic, readonly) NSError *nsError;
+
 #pragma mark - Constructors
 
 ///

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthResult.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthResult.m
@@ -66,7 +66,7 @@
 }
 
 + (DBOAuthResult *)unknownErrorWithErrorDescription:(NSString *)errorDescription {
-  return  [[DBOAuthResult alloc] initWithErrorType:DBAuthUnknown errorDescription:errorDescription];
+  return [[DBOAuthResult alloc] initWithErrorType:DBAuthUnknown errorDescription:errorDescription];
 }
 
 #pragma mark - Tag state methods
@@ -122,6 +122,14 @@
                 format:@"Invalid tag: required `DBAuthError`, but was %@.", [self tagName]];
   }
   return _errorDescription;
+}
+
+- (NSError *)nsError {
+  if (_tag != DBAuthError) {
+    [NSException raise:@"IllegalStateException"
+                format:@"Invalid tag: required `DBAuthError`, but was %@.", [self tagName]];
+  }
+  return [NSError errorWithDomain:@"com.dropbox.dropbox_sdk_obj_c.oauth.error" code:_errorType userInfo:nil];
 }
 
 #pragma mark - Description method


### PR DESCRIPTION
- Created `DBURLSessionTask` protocol to replace the usages of `NSURLSessionTask` in DBTask classes.
- Created `DBURLSessionTaskWithTokenRefresh` to inject token refresh before actually making API request.
- Refactored DBTask classes and related class to work with `DBURLSessionTask`.