### PR TITLE
Fixed OAuth response parsing

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Headers/Internal/OAuth/DBOAuthUtils.h
+++ b/Source/ObjectiveDropboxOfficial/Headers/Internal/OAuth/DBOAuthUtils.h
@@ -14,8 +14,17 @@ NS_ASSUME_NONNULL_BEGIN
 /// Creates URL query items needed by PKCE code flow.
 + (NSArray<NSURLQueryItem *> *)createPkceCodeFlowParamsForAuthSession:(DBOAuthPKCESession *)authSession;
 
-/// Extracts query parameters from URL and removes percent encoding.
-+ (NSDictionary<NSString *, NSString *> *)extractParamsFromUrl:(NSURL *)url;
+/// Extracts auth response parameters from URL and removes percent encoding.
+/// Response parameters from DAuth via the Dropbox app are in the query component.
++ (NSDictionary<NSString *, NSString *> *)extractDAuthResponseFromUrl:(NSURL *)url;
+
+/// Extracts auth response parameters from URL and removes percent encoding.
+/// Response parameters OAuth 2 code flow (RFC6749 4.1.2) are in the query component.
++ (NSDictionary<NSString *, NSString *> *)extractOAuthResponseFromCodeFlowUrl:(NSURL *)url;
+
+/// Extracts auth response parameters from URL and removes percent encoding.
+/// Response parameters from OAuth 2 token flow (RFC6749 4.2.2) are in the fragment component.
++ (NSDictionary<NSString *, NSString *> *)extractOAuthResponseFromTokenFlowUrl:(NSURL *)url;
 
 @end
 

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobileManager-iOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobileManager-iOS.m
@@ -187,7 +187,7 @@ static NSString *kDBLinkNonce = @"dropbox.sync.nonce";
 - (void)db_handleCodeFlowUrl:(NSURL *)url
                  authSession:(DBOAuthPKCESession *)authSession
                   completion:(DBOAuthCompletion)completion {
-  NSDictionary<NSString *, NSString *> *parametersMap = [DBOAuthUtils extractParamsFromUrl:url];
+  NSDictionary<NSString *, NSString *> *parametersMap = [DBOAuthUtils extractDAuthResponseFromUrl:url];
   NSString *state = parametersMap[kDBStateKey];
   if (state == nil || ![state isEqualToString:authSession.state]) {
     completion([DBOAuthResult unknownErrorWithErrorDescription:@"Unable to verify link request."]);
@@ -219,7 +219,7 @@ static NSString *kDBLinkNonce = @"dropbox.sync.nonce";
 /// ]
 /// @endcode
 - (DBOAuthResult *)db_extractFromTokenFlowUrl:(NSURL *)url {
-  NSDictionary<NSString *, NSString *> *parametersMap = [DBOAuthUtils extractParamsFromUrl:url];
+  NSDictionary<NSString *, NSString *> *parametersMap = [DBOAuthUtils extractDAuthResponseFromUrl:url];
   NSString *state = parametersMap[kDBStateKey];
   NSString *nonce = (NSString *)[[NSUserDefaults standardUserDefaults] objectForKey:kDBLinkNonce];
   NSString *expectedState = [NSString stringWithFormat:@"oauth2:%@", nonce];

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.m
@@ -312,7 +312,13 @@ static DBOAuthManager *s_sharedOAuthManager;
 /// ]
 /// @endcode
 - (void)extractAuthResultFromRedirectURL:(NSURL *)url completion:(DBOAuthCompletion)completion {
-  NSDictionary<NSString *, NSString *> *parametersMap = [DBOAuthUtils extractParamsFromUrl:url];
+  NSDictionary<NSString *, NSString *> *parametersMap = nil;
+  BOOL isInOAuthCodeFlow = _authSession != nil;
+  if (isInOAuthCodeFlow) {
+    parametersMap = [DBOAuthUtils extractOAuthResponseFromCodeFlowUrl:url];
+  } else {
+    parametersMap = [DBOAuthUtils extractOAuthResponseFromTokenFlowUrl:url];
+  }
   if (parametersMap[kDBErrorKey]) {
     // Error case
     DBOAuthResult *result = [[DBOAuthResult alloc] initWithError:parametersMap[kDBErrorKey]

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthUtils.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthUtils.m
@@ -31,8 +31,33 @@
   return params;
 }
 
-+ (NSDictionary<NSString *, NSString *> *)extractParamsFromUrl:(NSURL *)url {
+// Extracts auth response parameters from URL and removes percent encoding.
+// Response parameters from DAuth via the Dropbox app are in the query component.
++ (NSDictionary<NSString *, NSString *> *)extractDAuthResponseFromUrl:(NSURL *)url {
+  return [self extractQueryParamsFromUrl:url.absoluteString];
+}
+
+// Extracts auth response parameters from URL and removes percent encoding.
+// Response parameters OAuth 2 code flow (RFC6749 4.1.2) are in the query component.
++ (NSDictionary<NSString *, NSString *> *)extractOAuthResponseFromCodeFlowUrl:(NSURL *)url {
+  return [self extractQueryParamsFromUrl:url.absoluteString];
+}
+
+// Extracts auth response parameters from URL and removes percent encoding.
+// Response parameters from OAuth 2 token flow (RFC6749 4.2.2) are in the fragment component.
++ (NSDictionary<NSString *, NSString *> *)extractOAuthResponseFromTokenFlowUrl:(NSURL *)url {
   NSURLComponents *components = [[NSURLComponents alloc] initWithString:url.absoluteString];
+  if (components.fragment) {
+    // Create a query only URL string and extract its individual query parameters.
+    return [self extractQueryParamsFromUrl:[NSString stringWithFormat:@"?%@", components.fragment]];
+  } else {
+    return @{};
+  }
+}
+
+/// Extracts auth response parameters from URL and removes percent encoding.
++ (NSDictionary<NSString *, NSString *> *)extractQueryParamsFromUrl:(NSString *)url {
+  NSURLComponents *components = [[NSURLComponents alloc] initWithString:url];
   NSMutableDictionary<NSString *, NSString *> *dict = [NSMutableDictionary new];
   for (NSURLQueryItem *item in components.queryItems) {
     [dict setValue:item.value forKey:item.name];


### PR DESCRIPTION
OAuth 2 token flow response parameters are in the fragment component whereas OAuth 2 code flow response parameters are in the query component.
A previous commit that introduced code flow logic deleted the token flow response parsing code by accident, this is to fix the broken parsing logic.