### PR TITLE
Added OAuth code flow with PKCE and scopes support to Desktop SDK

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Headers/Internal/DBOAuthDesktop+Protected.h
+++ b/Source/ObjectiveDropboxOfficial/Headers/Internal/DBOAuthDesktop+Protected.h
@@ -1,0 +1,16 @@
+///
+/// Copyright (c) 2020 Dropbox, Inc. All rights reserved.
+///
+
+#import "DBLoadingStatusDelegate.h"
+#import "DBOAuthDesktop-MacOS.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface DBDesktopSharedApplication (Protected)
+
+@property (nonatomic, readwrite, weak) id<DBLoadingStatusDelegate> loadingStatusDelegate;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/ObjectiveDropboxOfficial/ObjectiveDropboxOfficial.xcodeproj/project.pbxproj
+++ b/Source/ObjectiveDropboxOfficial/ObjectiveDropboxOfficial.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		BF7E352C2488562F00DEDF84 /* DBLoadingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BF7E352A2488562F00DEDF84 /* DBLoadingViewController.m */; };
 		BF7E352E248858B600DEDF84 /* DBLoadingStatusDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = BF7E352D248858B600DEDF84 /* DBLoadingStatusDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF7E353024885A9A00DEDF84 /* DBOAuthMobile+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = BF7E352F24885A9A00DEDF84 /* DBOAuthMobile+Protected.h */; };
+		BFCE1FFD249C4D1200D11D8E /* DBOAuthDesktop+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = BFCE1FFC249C4D1200D11D8E /* DBOAuthDesktop+Protected.h */; };
 		BFD93BC724905D8A006AB165 /* DBAccessTokenProviderImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = BFD93BC624905D8A006AB165 /* DBAccessTokenProviderImpl.m */; };
 		BFD93BC824905D8A006AB165 /* DBAccessTokenProviderImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = BFD93BC624905D8A006AB165 /* DBAccessTokenProviderImpl.m */; };
 		C43D4E69245748BB008DF48C /* DBStoneBase.m in Sources */ = {isa = PBXBuildFile; fileRef = C43D46EE245748AF008DF48C /* DBStoneBase.m */; };
@@ -3962,6 +3963,7 @@
 		BF7E352F24885A9A00DEDF84 /* DBOAuthMobile+Protected.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DBOAuthMobile+Protected.h"; sourceTree = "<group>"; };
 		BFC20EA424905395005A5E8F /* DBAccessTokenProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DBAccessTokenProvider.h; sourceTree = "<group>"; };
 		BFC20EA524905C57005A5E8F /* DBAccessTokenProvider+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DBAccessTokenProvider+Internal.h"; sourceTree = "<group>"; };
+		BFCE1FFC249C4D1200D11D8E /* DBOAuthDesktop+Protected.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DBOAuthDesktop+Protected.h"; sourceTree = "<group>"; };
 		BFD93BC624905D8A006AB165 /* DBAccessTokenProviderImpl.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DBAccessTokenProviderImpl.m; sourceTree = "<group>"; };
 		C43D46EE245748AF008DF48C /* DBStoneBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DBStoneBase.m; sourceTree = "<group>"; };
 		C43D46EF245748AF008DF48C /* DBStoneSerializers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DBStoneSerializers.m; sourceTree = "<group>"; };
@@ -8378,6 +8380,7 @@
 			isa = PBXGroup;
 			children = (
 				BF7E352F24885A9A00DEDF84 /* DBOAuthMobile+Protected.h */,
+				BFCE1FFC249C4D1200D11D8E /* DBOAuthDesktop+Protected.h */,
 				F2A2CE751E562817001D8449 /* DBClientsManager+Protected.h */,
 				F2A2CE761E562817001D8449 /* Networking */,
 				F2C59AFB1E9C2EEC00E8D2E6 /* OAuth */,
@@ -10943,6 +10946,7 @@
 				C43D5924245748D1008DF48C /* DBTEAMLOGSsoChangePolicyDetails.h in Headers */,
 				C43D55D6245748CA008DF48C /* DBTEAMLOGShowcaseFileRemovedType.h in Headers */,
 				C43D5838245748CF008DF48C /* DBTEAMLOGMemberSpaceLimitsAddCustomQuotaDetails.h in Headers */,
+				BFCE1FFD249C4D1200D11D8E /* DBOAuthDesktop+Protected.h in Headers */,
 				C43D58B4245748D0008DF48C /* DBTEAMLOGEventType.h in Headers */,
 				C43D5954245748D1008DF48C /* DBTEAMLOGFileLockingLockStatusChangedDetails.h in Headers */,
 				C43D52F4245748C4008DF48C /* DBFILEPROPERTIESListTemplateResult.h in Headers */,

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBClientsManager+MobileAuth-iOS.h
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBClientsManager+MobileAuth-iOS.h
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param controller The `UIViewController` with which to render the OAuth flow. Please ensure that this is the
 /// top-most view controller, so that the authorization view displays correctly.
 /// @param loadingStatusDelegate An optional delegate to handle loading experience during auth flow.
-/// e.g. Show a looading spinner and block user interaction while loading/waiting.
+/// e.g. Show a loading spinner and block user interaction while loading/waiting.
 /// If a delegate is not provided, the SDK will show a default loading spinner when necessary.
 /// @param openURL A wrapper around app-extension unsafe `openURL` call.
 /// @param scopeRequest Request contains information of scopes to be obtained.

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBClientsManager+MobileAuth-iOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBClientsManager+MobileAuth-iOS.m
@@ -19,14 +19,12 @@
 + (void)authorizeFromController:(UIApplication *)sharedApplication
                      controller:(UIViewController *)controller
                         openURL:(void (^_Nonnull)(NSURL *))openURL {
-  NSAssert([DBOAuthManager sharedOAuthManager] != nil,
-           @"Call `Dropbox.setupWithAppKey` or `Dropbox.setupWithTeamAppKey` before calling this method");
-  DBMobileSharedApplication *sharedMobileApplication =
-      [[DBMobileSharedApplication alloc] initWithSharedApplication:sharedApplication
-                                                        controller:controller
-                                                           openURL:openURL];
-  [DBMobileSharedApplication setMobileSharedApplication:sharedMobileApplication];
-  [[DBOAuthManager sharedOAuthManager] authorizeFromSharedApplication:sharedMobileApplication];
+  [self db_authorizeFromController:sharedApplication
+                        controller:controller
+             loadingStatusDelegate:nil
+                           openURL:openURL
+                           usePkce:NO
+                      scopeRequest:nil];
 }
 
 + (void)authorizeFromControllerV2:(UIApplication *)sharedApplication
@@ -34,17 +32,12 @@
             loadingStatusDelegate:(nullable id<DBLoadingStatusDelegate>)loadingStatusDelegate
                           openURL:(void (^_Nonnull)(NSURL *))openURL
                      scopeRequest:(nullable DBScopeRequest*)scopeRequest {
-  NSAssert([DBOAuthManager sharedOAuthManager] != nil,
-           @"Call `Dropbox.setupWithAppKey` or `Dropbox.setupWithTeamAppKey` before calling this method");
-  DBMobileSharedApplication *sharedMobileApplication =
-  [[DBMobileSharedApplication alloc] initWithSharedApplication:sharedApplication
-                                                    controller:controller
-                                                       openURL:openURL];
-  sharedMobileApplication.loadingStatusDelegate = loadingStatusDelegate;
-  [DBMobileSharedApplication setMobileSharedApplication:sharedMobileApplication];
-  [[DBOAuthManager sharedOAuthManager] authorizeFromSharedApplication:sharedMobileApplication
-                                                              usePkce:YES
-                                                         scopeRequest:scopeRequest];
+  [self db_authorizeFromController:sharedApplication
+                        controller:controller
+             loadingStatusDelegate:loadingStatusDelegate
+                           openURL:openURL
+                           usePkce:YES
+                      scopeRequest:scopeRequest];
 }
 
 + (void)setupWithAppKey:(NSString *)appKey {
@@ -68,6 +61,27 @@
                                                                         host:transportConfig.hostnameConfig.meta
                                                                  redirectURL:transportConfig.redirectURL]
                 transportConfig:transportConfig];
+}
+
+#pragma - mark Private methods
+
++ (void)db_authorizeFromController:(UIApplication *)sharedApplication
+                        controller:(nullable UIViewController *)controller
+             loadingStatusDelegate:(nullable id<DBLoadingStatusDelegate>)loadingStatusDelegate
+                           openURL:(void (^_Nonnull)(NSURL *))openURL
+                           usePkce:(BOOL)usePkce
+                      scopeRequest:(nullable DBScopeRequest*)scopeRequest {
+  NSAssert([DBOAuthManager sharedOAuthManager] != nil,
+           @"Call `Dropbox.setupWithAppKey` or `Dropbox.setupWithTeamAppKey` before calling this method");
+  DBMobileSharedApplication *sharedMobileApplication =
+    [[DBMobileSharedApplication alloc] initWithSharedApplication:sharedApplication
+                                                      controller:controller
+                                                         openURL:openURL];
+  sharedMobileApplication.loadingStatusDelegate = loadingStatusDelegate;
+  [DBMobileSharedApplication setMobileSharedApplication:sharedMobileApplication];
+  [[DBOAuthManager sharedOAuthManager] authorizeFromSharedApplication:sharedMobileApplication
+                                                              usePkce:usePkce
+                                                         scopeRequest:scopeRequest];
 }
 
 @end

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBClientsManager+DesktopAuth-macOS.h
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBClientsManager+DesktopAuth-macOS.h
@@ -7,9 +7,12 @@
 #import "DBClientsManager.h"
 #import "DBOAuthDesktop-macOS.h"
 #import "DBOAuthResult.h"
+
 @class DBTransportDefaultConfig;
 @class NSWorkspace;
 @class NSViewController;
+
+@protocol DBLoadingStatusDelegate;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -30,6 +33,29 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)authorizeFromControllerDesktop:(NSWorkspace *)sharedApplication
                             controller:(nullable NSViewController *)controller
                                openURL:(void (^_Nonnull)(NSURL *))openURL;
+
+///
+/// Commences OAuth mobile flow from supplied view controller.
+///
+/// This starts the OAuth 2 Authorization Code Flow with PKCE.
+/// PKCE allows "authorization code" flow without "client_secret"
+/// It enables "native application", which is ensafe to hardcode client_secret in code, to use "authorization code".
+/// PKCE is more secure than "token" flow. If authorization code is compromised during
+/// transmission, it can't be used to exchange for access token without random generated
+/// code_verifier, which is stored inside this SDK.
+///
+/// @param sharedApplication The `NSWorkspace` with which to render the OAuth flow.
+/// @param controller The `NSViewController` with which to render the OAuth flow.
+/// @param loadingStatusDelegate An optional delegate to handle loading experience during auth flow.
+/// e.g. Show a loading spinner and block user interaction while loading/waiting.
+/// @param openURL A wrapper around app-extension unsafe `openURL` call.
+/// @param scopeRequest Request contains information of scopes to be obtained.
+///
++ (void)authorizeFromControllerDesktopV2:(NSWorkspace *)sharedApplication
+                              controller:(nullable NSViewController *)controller
+                   loadingStatusDelegate:(nullable id<DBLoadingStatusDelegate>)loadingStatusDelegate
+                                 openURL:(void (^_Nonnull)(NSURL *))openURL
+                            scopeRequest:(nullable DBScopeRequest*)scopeRequest;
 
 ///
 /// Stores the user app key for desktop. If any access token already exists, initializes an authorized shared

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBClientsManager+DesktopAuth-macOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBClientsManager+DesktopAuth-macOS.m
@@ -6,7 +6,9 @@
 
 #import "DBClientsManager+Protected.h"
 #import "DBClientsManager.h"
+#import "DBLoadingStatusDelegate.h"
 #import "DBOAuthDesktop-macOS.h"
+#import "DBOAuthDesktop+Protected.h"
 #import "DBOAuthManager.h"
 #import "DBTransportDefaultConfig.h"
 
@@ -15,13 +17,25 @@
 + (void)authorizeFromControllerDesktop:(NSWorkspace *)sharedApplication
                             controller:(NSViewController *)controller
                                openURL:(void (^_Nonnull)(NSURL *))openURL {
-  NSAssert([DBOAuthManager sharedOAuthManager] != nil,
-           @"Call `Dropbox.setupWithAppKey` or `Dropbox.setupWithTeamAppKey` before calling this method");
-  DBDesktopSharedApplication *sharedDesktopApplication =
-      [[DBDesktopSharedApplication alloc] initWithSharedApplication:sharedApplication
-                                                         controller:controller
-                                                            openURL:openURL];
-  [[DBOAuthManager sharedOAuthManager] authorizeFromSharedApplication:sharedDesktopApplication];
+  [self db_authorizeFromControllerDesktop:sharedApplication
+                               controller:controller
+                    loadingStatusDelegate:nil
+                                  openURL:openURL
+                                  usePkce:NO
+                             scopeRequest:nil];
+}
+
++ (void)authorizeFromControllerDesktopV2:(NSWorkspace *)sharedApplication
+                              controller:(nullable NSViewController *)controller
+                   loadingStatusDelegate:(nullable id<DBLoadingStatusDelegate>)loadingStatusDelegate
+                                 openURL:(void (^_Nonnull)(NSURL *))openURL
+                            scopeRequest:(nullable DBScopeRequest*)scopeRequest {
+  [self db_authorizeFromControllerDesktop:sharedApplication
+                               controller:controller
+                    loadingStatusDelegate:loadingStatusDelegate
+                                  openURL:openURL
+                                  usePkce:YES
+                             scopeRequest:scopeRequest];
 }
 
 + (void)setupWithAppKeyDesktop:(NSString *)appKey {
@@ -42,6 +56,27 @@
   [[self class] setupWithOAuthManagerTeam:[[DBOAuthManager alloc] initWithAppKey:transportConfig.appKey
                                                                             host:transportConfig.hostnameConfig.meta]
                           transportConfig:transportConfig];
+}
+
+#pragma - mark Private methods
+
++ (void)db_authorizeFromControllerDesktop:(NSWorkspace *)sharedApplication
+                               controller:(nullable NSViewController *)controller
+                    loadingStatusDelegate:(nullable id<DBLoadingStatusDelegate>)loadingStatusDelegate
+                                  openURL:(void (^_Nonnull)(NSURL *))openURL
+                                  usePkce:(BOOL)usePkce
+                             scopeRequest:(nullable DBScopeRequest*)scopeRequest {
+  NSAssert([DBOAuthManager sharedOAuthManager] != nil,
+           @"Call `Dropbox.setupWithAppKey` or `Dropbox.setupWithTeamAppKey` before calling this method");
+  DBDesktopSharedApplication *sharedDesktopApplication =
+    [[DBDesktopSharedApplication alloc] initWithSharedApplication:sharedApplication
+                                                       controller:controller
+                                                          openURL:openURL];
+  sharedDesktopApplication.loadingStatusDelegate = loadingStatusDelegate;
+  [DBDesktopSharedApplication setDesktopSharedApplication:sharedDesktopApplication];
+  [[DBOAuthManager sharedOAuthManager] authorizeFromSharedApplication:sharedDesktopApplication
+                                                              usePkce:usePkce
+                                                         scopeRequest:scopeRequest];
 }
 
 @end

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBOAuthDesktop-macOS.h
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBOAuthDesktop-macOS.h
@@ -16,6 +16,12 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 @interface DBDesktopSharedApplication : NSObject <DBSharedApplication>
 
+/// Returns the shared instance of `DBDesktopSharedApplication`.
++ (nullable DBDesktopSharedApplication *)desktopSharedApplication;
+
+/// Sets the shared instance of `DBDesktopSharedApplication`.
++ (void)setDesktopSharedApplication:(DBDesktopSharedApplication *)desktopSharedApplication;
+
 ///
 /// Full constructor.
 ///

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBOAuthDesktop-macOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBOAuthDesktop-macOS.m
@@ -3,12 +3,30 @@
 ///
 
 #import "DBOAuthDesktop-macOS.h"
+
+#import "DBLoadingStatusDelegate.h"
 #import "DBOAuthManager.h"
+
+static DBDesktopSharedApplication *s_desktopSharedApplication;
+
+@interface DBDesktopSharedApplication ()
+
+@property (nonatomic, readwrite, weak) id<DBLoadingStatusDelegate> loadingStatusDelegate;
+
+@end
 
 @implementation DBDesktopSharedApplication {
   NSWorkspace *_sharedWorkspace;
   NSViewController *_controller;
   void (^_openURL)(NSURL *);
+}
+
++ (DBDesktopSharedApplication *)desktopSharedApplication {
+  return s_desktopSharedApplication;
+}
+
++ (void)setDesktopSharedApplication:(DBDesktopSharedApplication *)desktopSharedApplication {
+  s_desktopSharedApplication = desktopSharedApplication;
 }
 
 - (instancetype)initWithSharedApplication:(NSWorkspace *)sharedWorkspace
@@ -62,11 +80,11 @@
 }
 
 - (void)presentLoading {
-  // TODO: Implement when OAuth code flow is introduced to Desktop SDK.
+  [_loadingStatusDelegate showLoading];
 }
 
 - (void)dismissLoading {
-  // TODO: Implement when OAuth code flow is introduced to Desktop SDK.
+  [_loadingStatusDelegate dismissLoading];
 }
 
 @end

--- a/TestObjectiveDropbox/TestObjectiveDropbox_iOS/Base.lproj/Main.storyboard
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_iOS/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -29,14 +27,14 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b9W-gk-MoP">
-                                <rect key="frame" x="112" y="258.5" width="152" height="30"/>
+                                <rect key="frame" x="111.5" y="258.5" width="152" height="30"/>
                                 <state key="normal" title="Link Dropbox Account"/>
                                 <connections>
-                                    <action selector="linkButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="e5P-LZ-Wih"/>
+                                    <action selector="tokenFlowlinkButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="L1r-FM-vZV"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="db5-aq-giW">
-                                <rect key="frame" x="140" y="118.5" width="95" height="30"/>
+                                <rect key="frame" x="140.5" y="118.5" width="94" height="30"/>
                                 <state key="normal" title="Run API Tests"/>
                                 <connections>
                                     <action selector="runTestsButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Lj1-FW-imk"/>
@@ -50,17 +48,24 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KMW-d6-mUc">
-                                <rect key="frame" x="108" y="158.5" width="160" height="30"/>
+                                <rect key="frame" x="107.5" y="158.5" width="160" height="30"/>
                                 <state key="normal" title="Run BatchUpload Tests"/>
                                 <connections>
                                     <action selector="runBatchUploadTestsButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="dhR-J7-UtW"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KTl-EQ-KEH">
-                                <rect key="frame" x="94" y="198.5" width="187" height="30"/>
+                                <rect key="frame" x="94.5" y="198.5" width="186" height="30"/>
                                 <state key="normal" title="Run Global Response Tests"/>
                                 <connections>
                                     <action selector="runGlobalResponseTestsButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="W88-Xe-Tty"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="luI-bu-yCb">
+                                <rect key="frame" x="52" y="288" width="270" height="30"/>
+                                <state key="normal" title="Link Dropbox Account (pkce code flow)"/>
+                                <connections>
+                                    <action selector="codeFlowlinkButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="y4x-3n-29X"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -73,19 +78,22 @@
                             <constraint firstItem="db5-aq-giW" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="O8l-MN-ZX0"/>
                             <constraint firstItem="lAs-Sd-MXl" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="QgU-hg-kg7"/>
                             <constraint firstItem="KTl-EQ-KEH" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="Qtc-hz-ejU"/>
+                            <constraint firstItem="luI-bu-yCb" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="Xya-JM-5VW"/>
                             <constraint firstItem="KTl-EQ-KEH" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" constant="-120" id="dgx-4H-ijK"/>
                             <constraint firstItem="KMW-d6-mUc" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" constant="-160" id="fmP-zU-y03"/>
                             <constraint firstItem="db5-aq-giW" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" constant="-200" id="g3I-ak-LGi"/>
                             <constraint firstItem="0Il-qF-Vab" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" constant="120" id="jvu-7a-pCX"/>
+                            <constraint firstItem="luI-bu-yCb" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" constant="-30" id="pHf-cb-Xs5"/>
                             <constraint firstItem="lAs-Sd-MXl" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="q5c-K2-FME"/>
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="linkButton" destination="b9W-gk-MoP" id="7Z8-pd-xJo"/>
+                        <outlet property="codeFlowlinkButton" destination="luI-bu-yCb" id="5Rm-tz-nnc"/>
                         <outlet property="openWithButton" destination="lAs-Sd-MXl" id="Z61-Mk-gKB"/>
                         <outlet property="runBatchUploadTestsButton" destination="KMW-d6-mUc" id="Ody-5w-o9z"/>
                         <outlet property="runGlobalResponseTestsButton" destination="KTl-EQ-KEH" id="Ion-L3-Ck9"/>
                         <outlet property="runTestsButton" destination="db5-aq-giW" id="UYY-YH-dIy"/>
+                        <outlet property="tokenFlowlinkButton" destination="b9W-gk-MoP" id="DvX-Jl-kU2"/>
                         <outlet property="unlinkButton" destination="0Il-qF-Vab" id="oAz-BA-Qf0"/>
                     </connections>
                 </viewController>

--- a/TestObjectiveDropbox/TestObjectiveDropbox_iOS/ViewController.m
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_iOS/ViewController.m
@@ -17,7 +17,8 @@ static DBOpenWithInfo *s_openWithInfoNSURL = nil;
 
 @interface ViewController ()
 
-@property (weak, nonatomic) IBOutlet UIButton *linkButton;
+@property (weak, nonatomic) IBOutlet UIButton *tokenFlowlinkButton;
+@property (weak, nonatomic) IBOutlet UIButton *codeFlowlinkButton;
 @property (weak, nonatomic) IBOutlet UIButton *runTestsButton;
 @property (weak, nonatomic) IBOutlet UIButton *unlinkButton;
 @property (weak, nonatomic) IBOutlet UIButton *openWithButton;
@@ -27,12 +28,24 @@ static DBOpenWithInfo *s_openWithInfoNSURL = nil;
 @end
 
 @implementation ViewController
-- (IBAction)linkButtonPressed:(id)sender {
-    [DBClientsManager authorizeFromController:[UIApplication sharedApplication]
+
+- (IBAction)tokenFlowlinkButton:(id)sender {
+  [DBClientsManager authorizeFromController:[UIApplication sharedApplication]
+                                      controller:self
+                                         openURL:^(NSURL *url) {
+                                           [[UIApplication sharedApplication] openURL:url];
+                                         }];
+}
+
+- (IBAction)codeFlowlinkButton:(id)sender {
+  DBScopeRequest *scopeRequest = [[DBScopeRequest alloc] initWithScopeType:DBScopeTypeUser
+                                                                    scopes:@[@"account_info.read"]
+                                                      includeGrantedScopes:NO];
+  [DBClientsManager authorizeFromControllerV2:[UIApplication sharedApplication]
                                    controller:self
-                                      openURL:^(NSURL *url) {
-        [[UIApplication sharedApplication] openURL:url];
-    }];
+                        loadingStatusDelegate:nil
+                                      openURL:^(NSURL *url) { [[UIApplication sharedApplication] openURL:url]; }
+                                 scopeRequest:scopeRequest];
 }
 
 - (IBAction)runTestsButtonPressed:(id)sender {
@@ -136,13 +149,15 @@ static DBOpenWithInfo *s_openWithInfoNSURL = nil;
 
 - (void)checkButtons {
     if ([DBClientsManager authorizedClient] || [DBClientsManager authorizedTeamClient]) {
-        _linkButton.hidden = YES;
+        _tokenFlowlinkButton.hidden = YES;
+        _codeFlowlinkButton.hidden = YES;
         _unlinkButton.hidden = NO;
         _runTestsButton.hidden = NO;
         _runBatchUploadTestsButton.hidden = NO;
         _runGlobalResponseTestsButton.hidden = NO;
     } else {
-        _linkButton.hidden = NO;
+        _tokenFlowlinkButton.hidden = NO;
+        _codeFlowlinkButton.hidden = NO;
         _unlinkButton.hidden = YES;
         _runTestsButton.hidden = YES;
         _runBatchUploadTestsButton.hidden = YES;

--- a/TestObjectiveDropbox/TestObjectiveDropbox_macOS/AppDelegate.m
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_macOS/AppDelegate.m
@@ -75,48 +75,29 @@ static ViewController *viewController = nil;
 
 - (void)handleAppleEvent:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescriptor *)replyEvent {
   NSURL *url = [NSURL URLWithString:[[event paramDescriptorForKeyword:keyDirectObject] stringValue]];
+  DBOAuthCompletion oauthCompletion = ^(DBOAuthResult *authResult) {
+    if (authResult != nil) {
+      if ([authResult isSuccess]) {
+        NSLog(@"\n\nSuccess! User is logged into Dropbox.\n\n");
+      } else if ([authResult isCancel]) {
+        NSLog(@"\n\nAuthorization flow was manually canceled by user!\n\n");
+      } else if ([authResult isError]) {
+        NSLog(@"\n\nError: %@\n\n", authResult);
+      }
+    }
+    [self checkButtons];
+  };
   switch (appPermission) {
     case FullDropbox: {
-      DBOAuthResult *authResult = [DBClientsManager handleRedirectURL:url];
-      if (authResult != nil) {
-        if ([authResult isSuccess]) {
-          NSLog(@"\n\nSuccess! User is logged into Dropbox.\n\n");
-        } else if ([authResult isCancel]) {
-          NSLog(@"\n\nAuthorization flow was manually canceled by user!\n\n");
-        } else if ([authResult isError]) {
-          NSLog(@"\n\nError: %@\n\n", authResult);
-        }
-      }
+      [DBClientsManager handleRedirectURL:url completion:oauthCompletion];
       break;
     }
-    case TeamMemberFileAccess: {
-      DBOAuthResult *authResult = [DBClientsManager handleRedirectURLTeam:url];
-      if (authResult != nil) {
-        if ([authResult isSuccess]) {
-          NSLog(@"Success! User is logged into Dropbox.");
-        } else if ([authResult isCancel]) {
-          NSLog(@"Authorization flow was manually canceled by user!");
-        } else if ([authResult isError]) {
-          NSLog(@"Error: %@", authResult);
-        }
-      }
-      break;
-    }
+    case TeamMemberFileAccess:
     case TeamMemberManagement: {
-      DBOAuthResult *authResult = [DBClientsManager handleRedirectURLTeam:url];
-      if (authResult != nil) {
-        if ([authResult isSuccess]) {
-          NSLog(@"Success! User is logged into Dropbox.");
-        } else if ([authResult isCancel]) {
-          NSLog(@"Authorization flow was manually canceled by user!");
-        } else if ([authResult isError]) {
-          NSLog(@"Error: %@", authResult);
-        }
-      }
+      [DBClientsManager handleRedirectURLTeam:url completion:oauthCompletion];
       break;
     }
   }
-  [self checkButtons];
   [[NSRunningApplication currentApplication]
       activateWithOptions:(NSApplicationActivateAllWindows | NSApplicationActivateIgnoringOtherApps)];
 }

--- a/TestObjectiveDropbox/TestObjectiveDropbox_macOS/Base.lproj/Main.storyboard
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_macOS/Base.lproj/Main.storyboard
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12118"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -651,11 +652,14 @@
         <scene sceneID="R2V-B0-nI4">
             <objects>
                 <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
-                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
+                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
                         <rect key="contentRect" x="196" y="240" width="480" height="270"/>
                         <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+                        <connections>
+                            <outlet property="delegate" destination="B8D-0N-5wS" id="U51-tg-D6j"/>
+                        </connections>
                     </window>
                     <connections>
                         <segue destination="XfG-lQ-9wD" kind="relationship" relationship="window.shadowedContentViewController" id="cq2-FE-JQM"/>
@@ -690,10 +694,10 @@
                                 <buttonCell key="cell" type="push" title="Link Dropbox" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="nfi-Ou-4Eh">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
-                                    <connections>
-                                        <action selector="linkButtonPressed:" target="XfG-lQ-9wD" id="EiK-ZO-GLS"/>
-                                    </connections>
                                 </buttonCell>
+                                <connections>
+                                    <action selector="tokenFlowLinkButtonPressed:" target="XfG-lQ-9wD" id="RbS-Bg-s07"/>
+                                </connections>
                             </button>
                             <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PxJ-2o-gM6">
                                 <rect key="frame" x="147" y="49" width="187" height="32"/>
@@ -706,12 +710,25 @@
                                     </connections>
                                 </buttonCell>
                             </button>
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CeA-c3-XyZ">
+                                <rect key="frame" x="128" y="109" width="225" height="32"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="push" title="Link Dropbox (pkce code flow)" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="OLd-P5-8H0">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="codeFlowLinkButtonPressed:" target="XfG-lQ-9wD" id="lHV-Dw-opw"/>
+                                </connections>
+                            </button>
                         </subviews>
                     </view>
                     <connections>
+                        <outlet property="codeFlowlinkButton" destination="CeA-c3-XyZ" id="VHV-VQ-Uoc"/>
                         <outlet property="linkButton" destination="nfi-Ou-4Eh" id="P7n-dk-wLf"/>
-                        <outlet property="runTestsButton" destination="EVG-9e-tp7" id="bSZ-VM-odB"/>
-                        <outlet property="unlinkButton" destination="Wry-RD-S07" id="KB9-Zr-6qo"/>
+                        <outlet property="runTestsButton" destination="3RD-VZ-XuW" id="P7n-ak-BV6"/>
+                        <outlet property="tokenFlowlinkButton" destination="SoD-Th-rjR" id="ayl-Xb-5dk"/>
+                        <outlet property="unlinkButton" destination="PxJ-2o-gM6" id="4gH-bj-ftR"/>
                     </connections>
                 </viewController>
                 <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>

--- a/TestObjectiveDropbox/TestObjectiveDropbox_macOS/ViewController.m
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_macOS/ViewController.m
@@ -14,20 +14,32 @@
 
 @interface ViewController ()
 
-@property(weak) IBOutlet NSButtonCell *linkButton;
-@property(weak) IBOutlet NSButtonCell *runTestsButton;
-@property(weak) IBOutlet NSButtonCell *unlinkButton;
+@property(weak) IBOutlet NSButton *tokenFlowlinkButton;
+@property(weak) IBOutlet NSButton *codeFlowlinkButton;
+@property(weak) IBOutlet NSButton *runTestsButton;
+@property(weak) IBOutlet NSButton *unlinkButton;
 
 @end
 
 @implementation ViewController
 
-- (IBAction)linkButtonPressed:(id)sender {
+- (IBAction)tokenFlowLinkButtonPressed:(id)sender {
     [DBClientsManager authorizeFromControllerDesktop:[NSWorkspace sharedWorkspace]
                                           controller:self
                                              openURL:^(NSURL *url) {
         [[NSWorkspace sharedWorkspace] openURL:url];
     }];
+}
+
+- (IBAction)codeFlowLinkButtonPressed:(id)sender {
+    DBScopeRequest *scopeRequest = [[DBScopeRequest alloc] initWithScopeType:DBScopeTypeUser
+                                                                      scopes:@[@"account_info.read"]
+                                                        includeGrantedScopes:NO];
+    [DBClientsManager authorizeFromControllerDesktopV2:[NSWorkspace sharedWorkspace]
+                                            controller:self
+                                 loadingStatusDelegate:nil
+                                               openURL:^(NSURL *url) { [[NSWorkspace sharedWorkspace] openURL:url]; }
+                                          scopeRequest:scopeRequest];
 }
 
 - (IBAction)runTestsButtonPressed:(id)sender {
@@ -73,11 +85,13 @@
 
 - (void)checkButtons {
     if ([DBClientsManager authorizedClient] || [DBClientsManager authorizedTeamClient]) {
-        [_linkButton setEnabled:NO];
+        [_tokenFlowlinkButton setEnabled:NO];
+        [_codeFlowlinkButton setEnabled:NO];
         [_unlinkButton setEnabled:YES];
         [_runTestsButton setEnabled:YES];
     } else {
-        [_linkButton setEnabled:YES];
+        [_tokenFlowlinkButton setEnabled:YES];
+        [_codeFlowlinkButton setEnabled:YES];
         [_unlinkButton setEnabled:NO];
         [_runTestsButton setEnabled:NO];
     }


### PR DESCRIPTION
- Created a new method `authorizeFromControllerDesktopV2:...` in `DBClientsManager` (DesktopAuth) to start the new auth flow.
- Added buttons in Mobile and Desktop test apps to start OAuth2 code flow with PKCE and scopes.