### PR TITLE
Fix DBScopeRequest imports for macOS

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBClientsManager+MobileAuth-iOS.h
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBClientsManager+MobileAuth-iOS.h
@@ -59,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
                        controller:(nullable UIViewController *)controller
             loadingStatusDelegate:(nullable id<DBLoadingStatusDelegate>)loadingStatusDelegate
                           openURL:(void (^_Nonnull)(NSURL *))openURL
-                     scopeRequest:(nullable DBScopeRequest*)scopeRequest;
+                     scopeRequest:(nullable DBScopeRequest *)scopeRequest;
 
 ///
 /// Stores the user app key. If any access token already exists, initializes an authorized shared `DBUserClient`

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBClientsManager+MobileAuth-iOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBClientsManager+MobileAuth-iOS.m
@@ -30,7 +30,7 @@
                        controller:(nullable UIViewController *)controller
             loadingStatusDelegate:(nullable id<DBLoadingStatusDelegate>)loadingStatusDelegate
                           openURL:(void (^_Nonnull)(NSURL *))openURL
-                     scopeRequest:(nullable DBScopeRequest*)scopeRequest {
+                     scopeRequest:(nullable DBScopeRequest *)scopeRequest {
   [self db_authorizeFromController:sharedApplication
                         controller:controller
              loadingStatusDelegate:loadingStatusDelegate
@@ -69,7 +69,7 @@
              loadingStatusDelegate:(nullable id<DBLoadingStatusDelegate>)loadingStatusDelegate
                            openURL:(void (^_Nonnull)(NSURL *))openURL
                            usePkce:(BOOL)usePkce
-                      scopeRequest:(nullable DBScopeRequest*)scopeRequest {
+                      scopeRequest:(nullable DBScopeRequest *)scopeRequest {
   NSAssert([DBOAuthManager sharedOAuthManager] != nil,
            @"Call `Dropbox.setupWithAppKey` or `Dropbox.setupWithTeamAppKey` before calling this method");
   DBMobileSharedApplication *sharedMobileApplication =

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBClientsManager+DesktopAuth-macOS.h
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBClientsManager+DesktopAuth-macOS.h
@@ -8,6 +8,7 @@
 #import "DBOAuthDesktop-macOS.h"
 #import "DBOAuthResult.h"
 
+@class DBScopeRequest;
 @class DBTransportDefaultConfig;
 @class NSWorkspace;
 @class NSViewController;
@@ -55,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
                               controller:(nullable NSViewController *)controller
                    loadingStatusDelegate:(nullable id<DBLoadingStatusDelegate>)loadingStatusDelegate
                                  openURL:(void (^_Nonnull)(NSURL *))openURL
-                            scopeRequest:(nullable DBScopeRequest*)scopeRequest;
+                            scopeRequest:(nullable DBScopeRequest *)scopeRequest;
 
 ///
 /// Stores the user app key for desktop. If any access token already exists, initializes an authorized shared

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBClientsManager+DesktopAuth-macOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBClientsManager+DesktopAuth-macOS.m
@@ -9,6 +9,7 @@
 #import "DBLoadingStatusDelegate.h"
 #import "DBOAuthDesktop-macOS.h"
 #import "DBOAuthManager.h"
+#import "DBScopeRequest.h"
 #import "DBTransportDefaultConfig.h"
 
 @implementation DBClientsManager (DesktopAuth)
@@ -28,7 +29,7 @@
                               controller:(nullable NSViewController *)controller
                    loadingStatusDelegate:(nullable id<DBLoadingStatusDelegate>)loadingStatusDelegate
                                  openURL:(void (^_Nonnull)(NSURL *))openURL
-                            scopeRequest:(nullable DBScopeRequest*)scopeRequest {
+                            scopeRequest:(nullable DBScopeRequest *)scopeRequest {
   [self db_authorizeFromControllerDesktop:sharedApplication
                                controller:controller
                     loadingStatusDelegate:loadingStatusDelegate
@@ -64,7 +65,7 @@
                     loadingStatusDelegate:(nullable id<DBLoadingStatusDelegate>)loadingStatusDelegate
                                   openURL:(void (^_Nonnull)(NSURL *))openURL
                                   usePkce:(BOOL)usePkce
-                             scopeRequest:(nullable DBScopeRequest*)scopeRequest {
+                             scopeRequest:(nullable DBScopeRequest *)scopeRequest {
   NSAssert([DBOAuthManager sharedOAuthManager] != nil,
            @"Call `Dropbox.setupWithAppKey` or `Dropbox.setupWithTeamAppKey` before calling this method");
   DBDesktopSharedApplication *sharedDesktopApplication =


### PR DESCRIPTION
For some reason this error was not caught by the test app.