### PR TITLE
Fix web oauth state mismatch

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.m
@@ -256,18 +256,16 @@ static DBOAuthManager *s_sharedOAuthManager;
     [NSURLQueryItem queryItemWithName:@"locale" value:[self db_localeIdentifier]],
   ] mutableCopy];
 
-  NSString *state = nil;
   if (_authSession) {
     // Code flow
-    state = _authSession.state;
     [queryItems addObjectsFromArray:[DBOAuthUtils createPkceCodeFlowParamsForAuthSession:_authSession]];
   } else {
     // Token flow
-    state = [[NSProcessInfo processInfo] globallyUniqueString];
     [queryItems addObject:[NSURLQueryItem queryItemWithName:@"response_type" value:@"token"]];
-    [queryItems addObject:[NSURLQueryItem queryItemWithName:@"state" value:state]];
   }
   // used to prevent malicious impersonation of app from web browser
+  NSString *state = [[NSProcessInfo processInfo] globallyUniqueString];
+  [queryItems addObject:[NSURLQueryItem queryItemWithName:kDBStateKey value:state]];
   [[NSUserDefaults standardUserDefaults] setValue:state forKey:kDBSDKCSRFKey];
 
   [queryItems addObject:[NSURLQueryItem queryItemWithName:@"force_reauthentication"

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthUtils.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthUtils.m
@@ -26,7 +26,6 @@
     [NSURLQueryItem queryItemWithName:kDBCodeChallengeMethodKey value:pkceData.codeChallengeMethod],
     [NSURLQueryItem queryItemWithName:kDBTokenAccessTypeKey value:authSession.tokenAccessType],
     [NSURLQueryItem queryItemWithName:kDBResponseTypeKey value:authSession.responseType],
-    [NSURLQueryItem queryItemWithName:kDBStateKey value:authSession.state],
   ]];
   return params;
 }


### PR DESCRIPTION
Use the global unique identifier as state string to avoid url encoding/decoding mismatch.