### PR TITLE
Fix for crashing in DBOAuthManager.refreshAccessToken with network er…

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthTokenRequest.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthTokenRequest.m
@@ -92,7 +92,7 @@
     result = [DBOAuthResult unknownErrorWithErrorDescription:error.localizedDescription];
   } else {
     // No network error, parse response data
-    NSDictionary<NSString *, id> *resultDict = [self resultDictionaryFromData:data];
+    NSDictionary<NSString *, id> *resultDict = [self db_resultDictionaryFromData:data];
     result = [self db_extractResultFromDict:resultDict];
   }
 
@@ -103,7 +103,10 @@
   _retainSelf = nil;
 }
 
-- (NSDictionary<NSString *, id> *)resultDictionaryFromData:(NSData *)data {
+- (NSDictionary<NSString *, id> *)db_resultDictionaryFromData:(NSData *)data {
+  if (data == nil) {
+    return nil;
+  }
   id json = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:nil];
   if ([json isKindOfClass:[NSDictionary<NSString *, id> class]]) {
     return json;

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthTokenRequest.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthTokenRequest.m
@@ -86,13 +86,13 @@
 
 - (void)db_handleResponse:(NSURLResponse *)response data:(NSData *)data error:(NSError *)error {
 #pragma unused(response)
-  NSDictionary<NSString *, id> *resultDict = [self resultDictionaryFromData:data];
   DBOAuthResult *result = nil;
   if (error) {
     // Network error
     result = [DBOAuthResult unknownErrorWithErrorDescription:error.localizedDescription];
   } else {
     // No network error, parse response data
+    NSDictionary<NSString *, id> *resultDict = [self resultDictionaryFromData:data];
     result = [self db_extractResultFromDict:resultDict];
   }
 


### PR DESCRIPTION
I confirm this crashing with:

ObjectiveDropboxOfficial: 5.0.4
iOS 14.2
iPad (6 Gen)

Crashing in DBOAuthManager.refreshAccessToken if it has network error because data parameter is nil and throw NSInvalidArgumentException by NSJSONSerialization.JSONObjectWithData.