### PR TITLE
Fix DBTask retain cycles

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasks.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasks.m
@@ -142,7 +142,7 @@
       @try {
         result = [DBTransportBaseClient routeResultWithRoute:route data:data serializationError:&serializationError];
       } @catch (NSException *exception) {
-        serializationError = [[self class] dropboxBadResponseErrorWithException:exception];
+        serializationError = [[strongSelf class] dropboxBadResponseErrorWithException:exception];
       }
       if (serializationError) {
         networkError = [[DBRequestError alloc] initAsClientError:serializationError];
@@ -237,7 +237,7 @@
       @try {
         result = [DBTransportBaseClient routeResultWithRoute:route data:data serializationError:&serializationError];
       } @catch (NSException *exception) {
-        serializationError = [[self class] dropboxBadResponseErrorWithException:exception];
+        serializationError = [[strongSelf class] dropboxBadResponseErrorWithException:exception];
       }
       if (serializationError) {
         networkError = [[DBRequestError alloc] initAsClientError:serializationError];
@@ -367,7 +367,7 @@
                                                             data:resultData
                                               serializationError:&serializationError];
           } @catch (NSException *exception) {
-            serializationError = [[self class] dropboxBadResponseErrorWithException:exception];
+            serializationError = [[strongSelf class] dropboxBadResponseErrorWithException:exception];
           }
           if (serializationError) {
             networkError = [[DBRequestError alloc] initAsClientError:serializationError];
@@ -479,7 +479,7 @@
         result =
             [DBTransportBaseClient routeResultWithRoute:route data:resultData serializationError:&serializationError];
       } @catch (NSException *exception) {
-        serializationError = [[self class] dropboxBadResponseErrorWithException:exception];
+        serializationError = [[strongSelf class] dropboxBadResponseErrorWithException:exception];
       }
       if (serializationError) {
         networkError = [[DBRequestError alloc] initAsClientError:serializationError];

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasksImpl.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasksImpl.m
@@ -67,9 +67,10 @@
 
 - (DBRpcTask *)setResponseBlock:(DBRpcResponseBlockImpl)responseBlock queue:(NSOperationQueue *)queue {
   _responseBlock = responseBlock;
+  __weak __typeof(self) weakSelf = self;
   DBRpcResponseBlockStorage storageBlock = [self storageBlockWithResponseBlock:responseBlock
                                                                   cleanupBlock:^{
-                                                                    [self cleanup];
+                                                                    [weakSelf cleanup];
                                                                   }];
   [_task setResponseBlock:[DBURLSessionTaskResponseBlockWrapper withRpcResponseBlock:storageBlock] queue:queue];
   return self;
@@ -145,9 +146,10 @@
 
 - (DBUploadTask *)setResponseBlock:(DBUploadResponseBlockImpl)responseBlock queue:(NSOperationQueue *)queue {
   _responseBlock = responseBlock;
+  __weak __typeof(self) weakSelf = self;
   DBUploadResponseBlockStorage storageBlock = [self storageBlockWithResponseBlock:responseBlock
                                                                      cleanupBlock:^{
-                                                                       [self cleanup];
+                                                                       [weakSelf cleanup];
                                                                      }];
   [_uploadTask setResponseBlock:[DBURLSessionTaskResponseBlockWrapper withUploadResponseBlock:storageBlock]
                           queue:queue];
@@ -234,9 +236,10 @@
 
 - (DBDownloadUrlTask *)setResponseBlock:(DBDownloadUrlResponseBlockImpl)responseBlock queue:(NSOperationQueue *)queue {
   _responseBlock = responseBlock;
+  __weak __typeof(self) weakSelf = self;
   DBDownloadResponseBlockStorage storageBlock = [self storageBlockWithResponseBlock:responseBlock
                                                                        cleanupBlock:^{
-                                                                         [self cleanup];
+                                                                         [weakSelf cleanup];
                                                                        }];
 
   [_downloadUrlTask setResponseBlock:[DBURLSessionTaskResponseBlockWrapper withDownloadResponseBlock:storageBlock]
@@ -316,9 +319,10 @@
 - (DBDownloadDataTask *)setResponseBlock:(DBDownloadDataResponseBlockImpl)responseBlock
                                    queue:(NSOperationQueue *)queue {
   _responseBlock = responseBlock;
+  __weak __typeof(self) weakSelf = self;
   DBDownloadResponseBlockStorage storageBlock = [self storageBlockWithResponseBlock:responseBlock
                                                                        cleanupBlock:^{
-                                                                         [self cleanup];
+                                                                         [weakSelf cleanup];
                                                                        }];
   [_downloadDataTask setResponseBlock:[DBURLSessionTaskResponseBlockWrapper withDownloadResponseBlock:storageBlock]
                                 queue:queue];


### PR DESCRIPTION
There are 2 retain cycles in DBTask, which prevents the task object from deallocing after the request is complete (and thus the response block never gets cleaned up). The first is in the cleanup block strongly capturing self with [self cleanup], and the second is in the response block wrapper using [self class] which also captures self.

![Screen Shot 2021-01-22 at 7 01 27 PM](https://user-images.githubusercontent.com/1757898/105779436-3e617300-5f23-11eb-820a-f20baa378c0a.png)
