### PR TITLE
Revert "Fix DBTask retain cycles" due to certain code paths needing the self retain

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasks.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasks.m
@@ -142,7 +142,7 @@
       @try {
         result = [DBTransportBaseClient routeResultWithRoute:route data:data serializationError:&serializationError];
       } @catch (NSException *exception) {
-        serializationError = [[strongSelf class] dropboxBadResponseErrorWithException:exception];
+        serializationError = [[self class] dropboxBadResponseErrorWithException:exception];
       }
       if (serializationError) {
         networkError = [[DBRequestError alloc] initAsClientError:serializationError];
@@ -237,7 +237,7 @@
       @try {
         result = [DBTransportBaseClient routeResultWithRoute:route data:data serializationError:&serializationError];
       } @catch (NSException *exception) {
-        serializationError = [[strongSelf class] dropboxBadResponseErrorWithException:exception];
+        serializationError = [[self class] dropboxBadResponseErrorWithException:exception];
       }
       if (serializationError) {
         networkError = [[DBRequestError alloc] initAsClientError:serializationError];
@@ -367,7 +367,7 @@
                                                             data:resultData
                                               serializationError:&serializationError];
           } @catch (NSException *exception) {
-            serializationError = [[strongSelf class] dropboxBadResponseErrorWithException:exception];
+            serializationError = [[self class] dropboxBadResponseErrorWithException:exception];
           }
           if (serializationError) {
             networkError = [[DBRequestError alloc] initAsClientError:serializationError];
@@ -479,7 +479,7 @@
         result =
             [DBTransportBaseClient routeResultWithRoute:route data:resultData serializationError:&serializationError];
       } @catch (NSException *exception) {
-        serializationError = [[strongSelf class] dropboxBadResponseErrorWithException:exception];
+        serializationError = [[self class] dropboxBadResponseErrorWithException:exception];
       }
       if (serializationError) {
         networkError = [[DBRequestError alloc] initAsClientError:serializationError];

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasksImpl.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasksImpl.m
@@ -67,10 +67,9 @@
 
 - (DBRpcTask *)setResponseBlock:(DBRpcResponseBlockImpl)responseBlock queue:(NSOperationQueue *)queue {
   _responseBlock = responseBlock;
-  __weak __typeof(self) weakSelf = self;
   DBRpcResponseBlockStorage storageBlock = [self storageBlockWithResponseBlock:responseBlock
                                                                   cleanupBlock:^{
-                                                                    [weakSelf cleanup];
+                                                                    [self cleanup];
                                                                   }];
   [_task setResponseBlock:[DBURLSessionTaskResponseBlockWrapper withRpcResponseBlock:storageBlock] queue:queue];
   return self;
@@ -146,10 +145,9 @@
 
 - (DBUploadTask *)setResponseBlock:(DBUploadResponseBlockImpl)responseBlock queue:(NSOperationQueue *)queue {
   _responseBlock = responseBlock;
-  __weak __typeof(self) weakSelf = self;
   DBUploadResponseBlockStorage storageBlock = [self storageBlockWithResponseBlock:responseBlock
                                                                      cleanupBlock:^{
-                                                                       [weakSelf cleanup];
+                                                                       [self cleanup];
                                                                      }];
   [_uploadTask setResponseBlock:[DBURLSessionTaskResponseBlockWrapper withUploadResponseBlock:storageBlock]
                           queue:queue];
@@ -236,10 +234,9 @@
 
 - (DBDownloadUrlTask *)setResponseBlock:(DBDownloadUrlResponseBlockImpl)responseBlock queue:(NSOperationQueue *)queue {
   _responseBlock = responseBlock;
-  __weak __typeof(self) weakSelf = self;
   DBDownloadResponseBlockStorage storageBlock = [self storageBlockWithResponseBlock:responseBlock
                                                                        cleanupBlock:^{
-                                                                         [weakSelf cleanup];
+                                                                         [self cleanup];
                                                                        }];
 
   [_downloadUrlTask setResponseBlock:[DBURLSessionTaskResponseBlockWrapper withDownloadResponseBlock:storageBlock]
@@ -319,10 +316,9 @@
 - (DBDownloadDataTask *)setResponseBlock:(DBDownloadDataResponseBlockImpl)responseBlock
                                    queue:(NSOperationQueue *)queue {
   _responseBlock = responseBlock;
-  __weak __typeof(self) weakSelf = self;
   DBDownloadResponseBlockStorage storageBlock = [self storageBlockWithResponseBlock:responseBlock
                                                                        cleanupBlock:^{
-                                                                         [weakSelf cleanup];
+                                                                         [self cleanup];
                                                                        }];
   [_downloadDataTask setResponseBlock:[DBURLSessionTaskResponseBlockWrapper withDownloadResponseBlock:storageBlock]
                                 queue:queue];


### PR DESCRIPTION
This reverts commit 55474bd3e4de1f8ea8a3fdc13fe24489b19f5134.

The commit above fixed retain cycles in DBTask. Certain code paths (for example, for download tasks) require the retain to keep itself (the DBTask) around until the request completes. 

People may have become dependent on this behavior and therefore not kept a reference to DBTasks themselves, and fixing the retain cycles would break them. So I am reverting the retain cycle fix.