### PR TITLE
Fix certain DBTask subclasses not actually setting their self-retain ivars

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasksImpl.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasksImpl.m
@@ -272,6 +272,7 @@
   self = [super initWithRoute:route tokenUid:tokenUid];
   if (self) {
     _downloadDataTask = task;
+    _selfRetained = self;
   }
   return self;
 }

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasksImpl.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasksImpl.m
@@ -98,6 +98,7 @@
   self = [super initWithRoute:route tokenUid:tokenUid];
   if (self) {
     _uploadTask = task;
+    _selfRetained = self;
   }
   return self;
 }
@@ -185,6 +186,7 @@
     _downloadUrlTask = task;
     _overwrite = overwrite;
     _destination = destination;
+    _selfRetained = self;
   }
   return self;
 }


### PR DESCRIPTION
Our DBTask impls have self-retaining code, but RPC tasks are the only ones that set the ivar. My previous fix that removed the retain cycles now made this self-retain necessary for use cases where the task instance is not being retained by the caller.