### PR TITLE
Add file routes unit test for iOS and remove auth tests for migrating oauth1 tokens

### DIFF
--- a/TestObjectiveDropbox/IntegrationTests/TestClasses.h
+++ b/TestObjectiveDropbox/IntegrationTests/TestClasses.h
@@ -65,7 +65,6 @@
 - (nonnull instancetype)init:(DropboxTester * _Nonnull)tester;
 
 - (void)tokenRevoke:(void (^_Nonnull)(void))nextTest;
-- (void)tokenFromOauth1:(void (^_Nonnull)(void))nextTest;
 
 @property DropboxTester * _Nonnull tester;
 
@@ -73,8 +72,8 @@
 
 @interface FilesTests : NSObject
 
-- (nonnull instancetype)init:(DropboxTester * _Nonnull)tester;
-
+- (instancetype _Nonnull )init:(DBFILESUserAuthRoutes *_Nonnull)filesRoute
+            testData:(TestData *_Nonnull)testData;
 - (void)deleteV2:(void (^_Nonnull)(void))nextTest;
 - (void)createFolderV2:(void (^_Nonnull)(void))nextTest;
 - (void)listFolderError:(void (^_Nonnull)(void))nextTest;
@@ -97,8 +96,6 @@
 - (void)uploadFile:(void (^_Nonnull)(void))nextTest;
 - (void)uploadStream:(void (^_Nonnull)(void))nextTest;
 - (void)listFolderLongpollAndTrigger:(void (^_Nonnull)(void))nextTest;
-
-@property DropboxTester * _Nonnull tester;
 
 @end
 

--- a/TestObjectiveDropbox/IntegrationTests/TestData.h
+++ b/TestObjectiveDropbox/IntegrationTests/TestData.h
@@ -58,10 +58,6 @@
 @property(nonatomic, copy) NSString * _Nonnull teamMemberEmail;
 @property(nonatomic, copy) NSString * _Nonnull teamMemberNewEmail;
 
-// OAuth 1.0 token
-@property(nonatomic, copy) NSString * _Nonnull oauth1Token;
-@property(nonatomic, copy) NSString * _Nonnull oauth1TokenSecret;
-
 // App key and secret
 @property(nonatomic, copy) NSString * _Nonnull fullDropboxAppKey;
 @property(nonatomic, copy) NSString * _Nonnull fullDropboxAppSecret;

--- a/TestObjectiveDropbox/IntegrationTests/TestData.m
+++ b/TestObjectiveDropbox/IntegrationTests/TestData.m
@@ -46,18 +46,14 @@
     // personal team data
     _teamMemberEmail = @"<EMAIL2>";
     _teamMemberNewEmail = @"<EMAIL3>";
-    
-    // OAuth 1.0 token
-    _oauth1Token = @"<OAUTH_1_TOKEN>";
-    _oauth1TokenSecret = @"<OAUTH_1_TOKEN_SECRET>";
-    
+
     // App key and secret
     _fullDropboxAppKey = @"<FULL_DROPBOX_APP_KEY>";
     _fullDropboxAppSecret = @"<FULL_DROPBOX_APP_SECRET>";
-    
+
     _teamMemberFileAccessAppKey = @"<TEAM_MEMBER_FILE_ACCESS_APP_KEY>";
     _teamMemberFileAccessAppSecret = @"<FULL_DROPBOX_APP_SECRET>";
-    
+
     _teamMemberManagementAppKey = @"<TEAM_MEMBER_MANAGEMENT_APP_KEY>";
     _teamMemberManagementAppSecret = @"<TEAM_MEMBER_MANAGEMENT_APP_SECRET>";
   }

--- a/TestObjectiveDropbox/Podfile
+++ b/TestObjectiveDropbox/Podfile
@@ -3,6 +3,9 @@ use_frameworks!
 target "TestObjectiveDropbox_iOS" do
     platform :ios, '9.0'
     pod 'ObjectiveDropboxOfficial', :path => '../'
+    target "TestObjectiveDropbox_iOSTests" do
+        pod 'ObjectiveDropboxOfficial', :path => '../'
+    end
 end
 
 target "TestObjectiveDropbox_macOS" do

--- a/TestObjectiveDropbox/Podfile.lock
+++ b/TestObjectiveDropbox/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - ObjectiveDropboxOfficial (5.0.3)
+  - ObjectiveDropboxOfficial (5.0.5)
 
 DEPENDENCIES:
   - ObjectiveDropboxOfficial (from `../`)
@@ -9,8 +9,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  ObjectiveDropboxOfficial: 4c9e5cfc3c5cb3ba73eed5fa659d1b3885f318d3
+  ObjectiveDropboxOfficial: 9ba0f4a3a9fdc914c2e660d759957328dd6cd744
 
-PODFILE CHECKSUM: ab0212b4bace4758ed2e1292c4087eec901dc0dc
+PODFILE CHECKSUM: 164683ff41a9f14efaeec568b26b59294bd5eb6d
 
-COCOAPODS: 1.9.1
+COCOAPODS: 1.8.3

--- a/TestObjectiveDropbox/TestObjectiveDropbox.xcodeproj/project.pbxproj
+++ b/TestObjectiveDropbox/TestObjectiveDropbox.xcodeproj/project.pbxproj
@@ -7,7 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0C1D1D6D26005BF800C88B6F /* FilesTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C1D1D6C26005BF800C88B6F /* FilesTestCase.m */; };
 		1BC94474BAF7A7BB8B521568 /* Pods_TestObjectiveDropbox_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E61D8320FDA365F90A8004D /* Pods_TestObjectiveDropbox_iOS.framework */; };
+		7D591876B62B5B205035C8E9 /* Pods_TestObjectiveDropbox_iOS_TestObjectiveDropbox_iOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D55835BD704F9EAAB8E89FB /* Pods_TestObjectiveDropbox_iOS_TestObjectiveDropbox_iOSTests.framework */; };
 		CB3E70120855B4B1ABCFF719 /* Pods_TestObjectiveDropbox_macOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EF03FDC09CC9F1D2179AB000 /* Pods_TestObjectiveDropbox_macOS.framework */; };
 		F23681561DEF647900D523C5 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F23681551DEF647900D523C5 /* AppDelegate.m */; };
 		F23681591DEF647900D523C5 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F23681581DEF647900D523C5 /* main.m */; };
@@ -26,11 +28,26 @@
 		F29BFD911D66290500994345 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F27BA80E1D63BBA100FB7864 /* ViewController.m */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		0C8ACA002600436100DE08FF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F27BA7FC1D63BBA100FB7864 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F27BA8031D63BBA100FB7864;
+			remoteInfo = TestObjectiveDropbox_iOS;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
+		0C1D1D6C26005BF800C88B6F /* FilesTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FilesTestCase.m; sourceTree = "<group>"; };
+		0C8AC9FB2600436100DE08FF /* TestObjectiveDropbox_iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestObjectiveDropbox_iOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		0C8AC9FF2600436100DE08FF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3D55835BD704F9EAAB8E89FB /* Pods_TestObjectiveDropbox_iOS_TestObjectiveDropbox_iOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TestObjectiveDropbox_iOS_TestObjectiveDropbox_iOSTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5E61D8320FDA365F90A8004D /* Pods_TestObjectiveDropbox_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TestObjectiveDropbox_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6554325D0AB7E5A7E226CCED /* Pods-TestObjectiveDropbox_macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestObjectiveDropbox_macOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TestObjectiveDropbox_macOS/Pods-TestObjectiveDropbox_macOS.debug.xcconfig"; sourceTree = "<group>"; };
 		65F9D9B80A170147CA9887A7 /* Pods-TestObjectiveDropbox_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestObjectiveDropbox_iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TestObjectiveDropbox_iOS/Pods-TestObjectiveDropbox_iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		6874E63CE61C80116147AFB0 /* Pods-TestObjectiveDropbox_macOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestObjectiveDropbox_macOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-TestObjectiveDropbox_macOS/Pods-TestObjectiveDropbox_macOS.release.xcconfig"; sourceTree = "<group>"; };
+		73F1A4955BD1AAF3362871A6 /* Pods-TestObjectiveDropbox_iOS-TestObjectiveDropbox_iOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestObjectiveDropbox_iOS-TestObjectiveDropbox_iOSTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TestObjectiveDropbox_iOS-TestObjectiveDropbox_iOSTests/Pods-TestObjectiveDropbox_iOS-TestObjectiveDropbox_iOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		E9403DCD149530530F654EE7 /* Pods-TestObjectiveDropbox_iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestObjectiveDropbox_iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-TestObjectiveDropbox_iOS/Pods-TestObjectiveDropbox_iOS.release.xcconfig"; sourceTree = "<group>"; };
 		EF03FDC09CC9F1D2179AB000 /* Pods_TestObjectiveDropbox_macOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TestObjectiveDropbox_macOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F23681521DEF647900D523C5 /* TestObjectiveDropbox_macOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestObjectiveDropbox_macOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -58,9 +75,18 @@
 		F27BA8161D63BBA100FB7864 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		F27BA8181D63BBA100FB7864 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F2A2CEBC1E567499001D8449 /* TestAppType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestAppType.h; sourceTree = "<group>"; };
+		F9D311DFBE6B027F6076CB5E /* Pods-TestObjectiveDropbox_iOS-TestObjectiveDropbox_iOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestObjectiveDropbox_iOS-TestObjectiveDropbox_iOSTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TestObjectiveDropbox_iOS-TestObjectiveDropbox_iOSTests/Pods-TestObjectiveDropbox_iOS-TestObjectiveDropbox_iOSTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		0C8AC9F82600436100DE08FF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7D591876B62B5B205035C8E9 /* Pods_TestObjectiveDropbox_iOS_TestObjectiveDropbox_iOSTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F236814F1DEF647900D523C5 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -85,8 +111,18 @@
 			children = (
 				5E61D8320FDA365F90A8004D /* Pods_TestObjectiveDropbox_iOS.framework */,
 				EF03FDC09CC9F1D2179AB000 /* Pods_TestObjectiveDropbox_macOS.framework */,
+				3D55835BD704F9EAAB8E89FB /* Pods_TestObjectiveDropbox_iOS_TestObjectiveDropbox_iOSTests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		0C8AC9FC2600436100DE08FF /* TestObjectiveDropbox_iOSTests */ = {
+			isa = PBXGroup;
+			children = (
+				0C1D1D6C26005BF800C88B6F /* FilesTestCase.m */,
+				0C8AC9FF2600436100DE08FF /* Info.plist */,
+			);
+			path = TestObjectiveDropbox_iOSTests;
 			sourceTree = "<group>";
 		};
 		92BE4CA0BA790784BB41BE84 /* Pods */ = {
@@ -96,6 +132,8 @@
 				E9403DCD149530530F654EE7 /* Pods-TestObjectiveDropbox_iOS.release.xcconfig */,
 				6554325D0AB7E5A7E226CCED /* Pods-TestObjectiveDropbox_macOS.debug.xcconfig */,
 				6874E63CE61C80116147AFB0 /* Pods-TestObjectiveDropbox_macOS.release.xcconfig */,
+				73F1A4955BD1AAF3362871A6 /* Pods-TestObjectiveDropbox_iOS-TestObjectiveDropbox_iOSTests.debug.xcconfig */,
+				F9D311DFBE6B027F6076CB5E /* Pods-TestObjectiveDropbox_iOS-TestObjectiveDropbox_iOSTests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -141,6 +179,7 @@
 				F23681661DEF672800D523C5 /* IntegrationTests */,
 				F27BA8061D63BBA100FB7864 /* TestObjectiveDropbox_iOS */,
 				F23681531DEF647900D523C5 /* TestObjectiveDropbox_macOS */,
+				0C8AC9FC2600436100DE08FF /* TestObjectiveDropbox_iOSTests */,
 				F27BA8051D63BBA100FB7864 /* Products */,
 				92BE4CA0BA790784BB41BE84 /* Pods */,
 				017405FC24A1CAB655318F53 /* Frameworks */,
@@ -152,6 +191,7 @@
 			children = (
 				F27BA8041D63BBA100FB7864 /* TestObjectiveDropbox_iOS.app */,
 				F23681521DEF647900D523C5 /* TestObjectiveDropbox_macOS.app */,
+				0C8AC9FB2600436100DE08FF /* TestObjectiveDropbox_iOSTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -184,6 +224,26 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		0C8AC9FA2600436100DE08FF /* TestObjectiveDropbox_iOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0C8ACA022600436100DE08FF /* Build configuration list for PBXNativeTarget "TestObjectiveDropbox_iOSTests" */;
+			buildPhases = (
+				734E96A937D7B6C649E665C0 /* [CP] Check Pods Manifest.lock */,
+				0C8AC9F72600436100DE08FF /* Sources */,
+				0C8AC9F82600436100DE08FF /* Frameworks */,
+				0C8AC9F92600436100DE08FF /* Resources */,
+				7D898F5BF97042BCF0B78572 /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0C8ACA012600436100DE08FF /* PBXTargetDependency */,
+			);
+			name = TestObjectiveDropbox_iOSTests;
+			productName = TestObjectiveDropbox_iOSTests;
+			productReference = 0C8AC9FB2600436100DE08FF /* TestObjectiveDropbox_iOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		F23681511DEF647900D523C5 /* TestObjectiveDropbox_macOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F23681651DEF647900D523C5 /* Build configuration list for PBXNativeTarget "TestObjectiveDropbox_macOS" */;
@@ -231,6 +291,11 @@
 				LastUpgradeCheck = 1140;
 				ORGANIZATIONNAME = Dropbox;
 				TargetAttributes = {
+					0C8AC9FA2600436100DE08FF = {
+						CreatedOnToolsVersion = 12.4;
+						ProvisioningStyle = Automatic;
+						TestTargetID = F27BA8031D63BBA100FB7864;
+					};
 					F23681511DEF647900D523C5 = {
 						CreatedOnToolsVersion = 8.1;
 						ProvisioningStyle = Automatic;
@@ -262,11 +327,19 @@
 			targets = (
 				F27BA8031D63BBA100FB7864 /* TestObjectiveDropbox_iOS */,
 				F23681511DEF647900D523C5 /* TestObjectiveDropbox_macOS */,
+				0C8AC9FA2600436100DE08FF /* TestObjectiveDropbox_iOSTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		0C8AC9F92600436100DE08FF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F23681501DEF647900D523C5 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -325,6 +398,28 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		734E96A937D7B6C649E665C0 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-TestObjectiveDropbox_iOS-TestObjectiveDropbox_iOSTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		7A03DFCDE9686959E9D77EEE /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -341,6 +436,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TestObjectiveDropbox_iOS/Pods-TestObjectiveDropbox_iOS-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		7D898F5BF97042BCF0B78572 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-TestObjectiveDropbox_iOS-TestObjectiveDropbox_iOSTests/Pods-TestObjectiveDropbox_iOS-TestObjectiveDropbox_iOSTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/ObjectiveDropboxOfficial-iOS/ObjectiveDropboxOfficial.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ObjectiveDropboxOfficial.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TestObjectiveDropbox_iOS-TestObjectiveDropbox_iOSTests/Pods-TestObjectiveDropbox_iOS-TestObjectiveDropbox_iOSTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		A869A6A9C6E78EBA3DB6CAA1 /* [CP] Check Pods Manifest.lock */ = {
@@ -364,6 +477,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		0C8AC9F72600436100DE08FF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0C1D1D6D26005BF800C88B6F /* FilesTestCase.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F236814E1DEF647900D523C5 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -389,6 +510,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		0C8ACA012600436100DE08FF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F27BA8031D63BBA100FB7864 /* TestObjectiveDropbox_iOS */;
+			targetProxy = 0C8ACA002600436100DE08FF /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		F236815F1DEF647900D523C5 /* Main.storyboard */ = {
@@ -418,6 +547,55 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		0C8ACA032600436100DE08FF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 73F1A4955BD1AAF3362871A6 /* Pods-TestObjectiveDropbox_iOS-TestObjectiveDropbox_iOSTests.debug.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = TestObjectiveDropbox_iOSTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.getdropbox.TestObjectiveDropbox-iOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestObjectiveDropbox_iOS.app/TestObjectiveDropbox_iOS";
+			};
+			name = Debug;
+		};
+		0C8ACA042600436100DE08FF /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F9D311DFBE6B027F6076CB5E /* Pods-TestObjectiveDropbox_iOS-TestObjectiveDropbox_iOSTests.release.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = TestObjectiveDropbox_iOSTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.getdropbox.TestObjectiveDropbox-iOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestObjectiveDropbox_iOS.app/TestObjectiveDropbox_iOS";
+			};
+			name = Release;
+		};
 		F23681631DEF647900D523C5 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6554325D0AB7E5A7E226CCED /* Pods-TestObjectiveDropbox_macOS.debug.xcconfig */;
@@ -599,6 +777,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		0C8ACA022600436100DE08FF /* Build configuration list for PBXNativeTarget "TestObjectiveDropbox_iOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0C8ACA032600436100DE08FF /* Debug */,
+				0C8ACA042600436100DE08FF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		F23681651DEF647900D523C5 /* Build configuration list for PBXNativeTarget "TestObjectiveDropbox_macOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/TestObjectiveDropbox/TestObjectiveDropbox.xcodeproj/xcshareddata/xcschemes/TestObjectiveDropbox_iOS.xcscheme
+++ b/TestObjectiveDropbox/TestObjectiveDropbox.xcodeproj/xcshareddata/xcschemes/TestObjectiveDropbox_iOS.xcscheme
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1240"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F27BA8031D63BBA100FB7864"
+               BuildableName = "TestObjectiveDropbox_iOS.app"
+               BlueprintName = "TestObjectiveDropbox_iOS"
+               ReferencedContainer = "container:TestObjectiveDropbox.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0C8AC9FA2600436100DE08FF"
+            BuildableName = "TestObjectiveDropbox_iOSTests.xctest"
+            BlueprintName = "TestObjectiveDropbox_iOSTests"
+            ReferencedContainer = "container:TestObjectiveDropbox.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "FULL_DROPBOX_API_APP_SECRET"
+            value = "$(FULL_DROPBOX_API_APP_SECRET)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "FULL_DROPBOX_USER_OAUTH2_TOKEN"
+            value = "$(FULL_DROPBOX_USER_OAUTH2_TOKEN)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "FULL_DROPBOX_API_APP_KEY"
+            value = "$(FULL_DROPBOX_API_APP_KEY)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0C8AC9FA2600436100DE08FF"
+               BuildableName = "TestObjectiveDropbox_iOSTests.xctest"
+               BlueprintName = "TestObjectiveDropbox_iOSTests"
+               ReferencedContainer = "container:TestObjectiveDropbox.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F27BA8031D63BBA100FB7864"
+            BuildableName = "TestObjectiveDropbox_iOS.app"
+            BlueprintName = "TestObjectiveDropbox_iOS"
+            ReferencedContainer = "container:TestObjectiveDropbox.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F27BA8031D63BBA100FB7864"
+            BuildableName = "TestObjectiveDropbox_iOS.app"
+            BlueprintName = "TestObjectiveDropbox_iOS"
+            ReferencedContainer = "container:TestObjectiveDropbox.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/TestObjectiveDropbox/TestObjectiveDropbox_iOS/AppDelegate.m
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_iOS/AppDelegate.m
@@ -19,6 +19,12 @@
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    if([[NSProcessInfo processInfo] environment][@"XCTestConfigurationFilePath"] != nil) {
+        // running unit tests
+        self.window.rootViewController = [[UIViewController alloc] init];
+        return YES;
+    }
+
   TestData *data = [TestData new];
 
   if ([data.fullDropboxAppSecret containsString:@"<"] ||

--- a/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/FilesTestCase.m
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/FilesTestCase.m
@@ -1,0 +1,104 @@
+#import <XCTest/XCTest.h>
+#import "TestClasses.h"
+#import <ObjectiveDropboxOfficial/ObjectiveDropboxOfficial.h>
+
+@interface FilesTestCase : XCTestCase
+
+@end
+
+@implementation FilesTestCase {
+    NSOperationQueue *_delegateQueue;
+    DBUserClient* _userClient;
+    FilesTests *_fileTests;
+}
+
+- (void)setUp {
+    NSDictionary<NSString *, NSString *> *processInfoDict = [[NSProcessInfo processInfo] environment];
+
+    // You need an API app with the "Full Dropbox" permission type.
+    // You can create one for testing here: https://www.dropbox.com/developers/apps/create
+    // The 'App key' and 'App secret' will be on the app's info page.
+    // Then click 'Generate' under "Generated access token" to get an oauth2 token.
+    // Once you have these 3 values, add them to the Scheme's Test action's environment variables.
+    NSString *apiAppKey = processInfoDict[@"FULL_DROPBOX_API_APP_KEY"];
+    NSString *apiAppSecret = processInfoDict[@"FULL_DROPBOX_API_APP_SECRET"];
+    NSString *oauth2Token = processInfoDict[@"FULL_DROPBOX_USER_OAUTH2_TOKEN"];
+    XCTAssertNotNil(apiAppKey, @"FULL_DROPBOX_API_APP_KEY needs to be set in the test Scheme");
+    XCTAssertNotNil(apiAppSecret, @"FULL_DROPBOX_API_APP_SECRET needs to be set in the test Scheme");
+    XCTAssertNotNil(oauth2Token, @"FULL_DROPBOX_USER_OAUTH2_TOKEN needs to be set in the test Scheme");
+
+    _delegateQueue = [[NSOperationQueue alloc] init];
+    DBTransportDefaultConfig *transportConfigFullDropbox =
+      [[DBTransportDefaultConfig alloc] initWithAppKey:apiAppKey
+                                             appSecret:apiAppSecret
+                                             userAgent:nil
+                                            asMemberId:nil
+                                         delegateQueue:_delegateQueue
+                                forceForegroundSession:NO
+                             sharedContainerIdentifier:nil];
+    _userClient = [[DBUserClient alloc] initWithAccessToken:oauth2Token
+        transportConfig:transportConfigFullDropbox];
+    _fileTests = [[FilesTests alloc] init:_userClient.filesRoutes testData:[[TestData alloc] init]];
+}
+
+-(void)tearDown {
+    [self runTestAndWait:@selector(deleteV2:)]; // delete to cleanup
+}
+
+// This is an XCTest implementation of the files tests.
+// Ordering seems to matter, since the account has state, so we can't split
+// this into multiple tests.
+// Failures will assert (ie crash the runner). This can be changed to XCTFail
+// in the future so that we can at least cleanup the account (ie delete the folder).
+- (void)testFileRoutes {
+
+    [TestFormat printTestBegin:NSStringFromSelector(_cmd)];
+
+    [self runTestAndWait:@selector(deleteV2:)]; // delete in case of leftover from another test
+    [self runTestAndWait:@selector(createFolderV2:)];
+    [self runTestAndWait:@selector(listFolderError:)];
+    [self runTestAndWait:@selector(listFolder:)];
+    [self runTestAndWait:@selector(uploadData:)];
+    [self runTestAndWait:@selector(uploadDataSession:)];
+    [self runTestAndWait:@selector(dCopyV2:)];
+    [self runTestAndWait:@selector(dCopyReferenceGet:)];
+    [self runTestAndWait:@selector(getMetadataError:)];
+    [self runTestAndWait:@selector(getTemporaryLink:)];
+    [self runTestAndWait:@selector(listRevisions:)];
+    [self runTestAndWait:@selector(moveV2:)];
+
+    // do this manually since this one has an extra argument
+    XCTestExpectation *flag = [[XCTestExpectation alloc] init];
+    [_fileTests saveUrl:^{
+        [flag fulfill];
+    } asMember:NO];
+    [self waitForExpectations:@[flag] timeout:3];
+
+    [self runTestAndWait:@selector(downloadToFile:)];
+    [self runTestAndWait:@selector(downloadToFileAgain:)];
+    [self runTestAndWait:@selector(downloadToMemory:)];
+    [self runTestAndWait:@selector(downloadToMemoryWithRange:)];
+    [self runTestAndWait:@selector(uploadFile:)];
+    [self runTestAndWait:@selector(uploadStream:)];
+    [self runTestAndWait:@selector(listFolderLongpollAndTrigger:)];
+
+    [TestFormat printTestEnd];
+}
+
+// Test selector must have completion block as only argument
+// This is dirty I know, this would be cleaner in Swift since methods are objects.
+- (void)runTestAndWait:(SEL)testSelector {
+    XCTestExpectation *flag = [[XCTestExpectation alloc] init];
+
+    // supress "performSelector may cause a leak because its selector is unknown" warning
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+    [_fileTests performSelector:testSelector withObject:^{
+        [flag fulfill];
+    }];
+#pragma clang diagnostic pop
+
+    [self waitForExpectations:@[flag] timeout:3];
+}
+
+@end

--- a/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/Info.plist
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>


### PR DESCRIPTION
We have "tests" in this sdk, but it can't be run without tapping on the UI and manually setting up url scheme and test data in the project.
This pull request adds a unit test target in the iOS tests project so that tests can be run as part of xcodebuild's test action.

There is only one test so far: the test for file routes on the iOS platform. Note that customizable test data (api app secret, key and oauth2 token) are passed in via the scheme's environment variable, allowing these to be passed via the command line. Also note that this pull request doesn't write any tests; it uses the same tests as before, but allows the tests to be run via XCTestCase.

This pull request also removes the test for migration oauth1 tokens. It is hard to get oauth1 tokens for testing now and this test isn't really needed anymore.