### PR TITLE
Bug fix: clearAllTokens should remove all tokens in keychain

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBSDKKeychain.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBSDKKeychain.m
@@ -103,7 +103,15 @@ static const char *kV1OSXAccountName = "Dropbox";
 }
 
 + (BOOL)clearAllTokens {
+  // According to Apple documentation, SecItemDelete should delete all matching items by default.
+  // The default behavior works fine on iOS, but not on macOS.
+  // An extra parameter is required to be able to delete all items on macOS, but this same parameter
+  // would result in an error on iOS. So only add it on macOS.
+#ifdef TARGET_OS_MAC
   NSMutableDictionary<id, id> *query = [DBSDKKeychain queryWithDict:@{(id)kSecMatchLimit : (id)kSecMatchLimitAll}];
+#else
+  NSMutableDictionary<id, id> *query = [DBSDKKeychain queryWithDict:@{}];
+#endif
   return SecItemDelete((__bridge CFDictionaryRef)query) == noErr;
 }
 

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBSDKKeychain.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBSDKKeychain.m
@@ -103,7 +103,7 @@ static const char *kV1OSXAccountName = "Dropbox";
 }
 
 + (BOOL)clearAllTokens {
-  NSMutableDictionary<id, id> *query = [DBSDKKeychain queryWithDict:@{}];
+  NSMutableDictionary<id, id> *query = [DBSDKKeychain queryWithDict:@{(id)kSecMatchLimit : (id)kSecMatchLimitAll}];
   return SecItemDelete((__bridge CFDictionaryRef)query) == noErr;
 }
 

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBSDKKeychain.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBSDKKeychain.m
@@ -107,7 +107,7 @@ static const char *kV1OSXAccountName = "Dropbox";
   // The default behavior works fine on iOS, but not on macOS.
   // An extra parameter is required to be able to delete all items on macOS, but this same parameter
   // would result in an error on iOS. So only add it on macOS.
-#ifdef TARGET_OS_MAC
+#if TARGET_OS_OSX
   NSMutableDictionary<id, id> *query = [DBSDKKeychain queryWithDict:@{(id)kSecMatchLimit : (id)kSecMatchLimitAll}];
 #else
   NSMutableDictionary<id, id> *query = [DBSDKKeychain queryWithDict:@{}];


### PR DESCRIPTION
[DBSDKKeychain queryWithDict:@{}] only delete one token in the keychain under MacOS. Use kSecMatchLimitAll to delete all matched tokens.