### PR TITLE
Make controller in DBMobileSharedApplication and DBDesktopSharedApplication a weak reference

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBClientsManager+MobileAuth-iOS.h
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBClientsManager+MobileAuth-iOS.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// @param sharedApplication The `UIApplication` with which to render the OAuth flow.
 /// @param controller The `UIViewController` with which to render the OAuth flow. Please ensure that this is the
-/// top-most view controller, so that the authorization view displays correctly.
+/// top-most view controller, so that the authorization view displays correctly. The controller reference is weakly held.
 /// @param openURL A wrapper around app-extension unsafe `openURL` call.
 ///
 + (void)authorizeFromController:(UIApplication *)sharedApplication
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// @param sharedApplication The `UIApplication` with which to render the OAuth flow.
 /// @param controller The `UIViewController` with which to render the OAuth flow. Please ensure that this is the
-/// top-most view controller, so that the authorization view displays correctly.
+/// top-most view controller, so that the authorization view displays correctly. The controller reference is weakly held.
 /// @param loadingStatusDelegate An optional delegate to handle loading experience during auth flow.
 /// e.g. Show a loading spinner and block user interaction while loading/waiting.
 /// If a delegate is not provided, the SDK will show a default loading spinner when necessary.

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobile-iOS.h
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobile-iOS.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Full constructor.
 ///
 /// @param sharedApplication The `UIApplication` with which to render the OAuth flow.
-/// @param controller The `UIViewController` with which to render the OAuth flow.
+/// @param controller The `UIViewController` with which to render the OAuth flow. The controller reference is weakly held.
 /// @param openURL A wrapper around app-extension unsafe `openURL` call.
 ///
 /// @return An initialized instance.

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobile-iOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobile-iOS.m
@@ -15,7 +15,7 @@ static DBMobileSharedApplication *s_mobileSharedApplication;
 
 @implementation DBMobileSharedApplication {
   UIApplication *_sharedApplication;
-    __weak UIViewController * _Nullable _controller;
+  __weak UIViewController * _Nullable _controller;
   void (^_openURL)(NSURL *);
 }
 

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobile-iOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobile-iOS.m
@@ -15,7 +15,7 @@ static DBMobileSharedApplication *s_mobileSharedApplication;
 
 @implementation DBMobileSharedApplication {
   UIApplication *_sharedApplication;
-  UIViewController *_controller;
+    __weak UIViewController * _Nullable _controller;
   void (^_openURL)(NSURL *);
 }
 

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBClientsManager+DesktopAuth-macOS.h
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBClientsManager+DesktopAuth-macOS.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Commences OAuth desktop flow from supplied view controller.
 ///
 /// @param sharedApplication The `NSWorkspace` with which to render the OAuth flow.
-/// @param controller The `NSViewController` with which to render the OAuth flow.
+/// @param controller The `NSViewController` with which to render the OAuth flow. The controller reference is weakly held.
 /// @param openURL A wrapper around app-extension unsafe `openURL` call.
 ///
 + (void)authorizeFromControllerDesktop:(NSWorkspace *)sharedApplication
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// code_verifier, which is stored inside this SDK.
 ///
 /// @param sharedApplication The `NSWorkspace` with which to render the OAuth flow.
-/// @param controller The `NSViewController` with which to render the OAuth flow.
+/// @param controller The `NSViewController` with which to render the OAuth flow. The controller reference is weakly held.
 /// @param loadingStatusDelegate An optional delegate to handle loading experience during auth flow.
 /// e.g. Show a loading spinner and block user interaction while loading/waiting.
 /// @param openURL A wrapper around app-extension unsafe `openURL` call.

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBOAuthDesktop-macOS.h
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBOAuthDesktop-macOS.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Full constructor.
 ///
 /// @param sharedApplication The `NSWorkspace` with which to render the OAuth flow.
-/// @param controller The `NSViewController` with which to render the OAuth flow.
+/// @param controller The `NSViewController` with which to render the OAuth flow. The controller reference is weakly held.
 /// @param openURL A wrapper around app-extension unsafe `openURL` call.
 ///
 /// @return An initialized instance.

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBOAuthDesktop-macOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBOAuthDesktop-macOS.m
@@ -11,7 +11,7 @@ static DBDesktopSharedApplication *s_desktopSharedApplication;
 
 @implementation DBDesktopSharedApplication {
   NSWorkspace *_sharedWorkspace;
-  NSViewController *_controller;
+    __weak NSViewController * _Nullable _controller;
   void (^_openURL)(NSURL *);
 }
 

--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBOAuthDesktop-macOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/DBOAuthDesktop-macOS.m
@@ -11,7 +11,7 @@ static DBDesktopSharedApplication *s_desktopSharedApplication;
 
 @implementation DBDesktopSharedApplication {
   NSWorkspace *_sharedWorkspace;
-    __weak NSViewController * _Nullable _controller;
+  __weak NSViewController * _Nullable _controller;
   void (^_openURL)(NSURL *);
 }
 


### PR DESCRIPTION
Addresses https://github.com/dropbox/dropbox-sdk-obj-c/issues/165

These are singletons so they were retaining the controller forever.
This may require a major update as it is changing behavior that isn't backwards compatible. However I can't see this breaking anything for others because the controller should be held strongly in the view hierarchy.