### PR TITLE
Properly handle route errors from file urls so that download routes propogate route errors

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasks.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasks.m
@@ -329,7 +329,7 @@
 
     if (clientError || !resultData || !location) {
       // error data is in response body (downloaded to output tmp file)
-      NSData *errorData = location ? [NSData dataWithContentsOfURL:location] : nil;
+      NSData *errorData = location ? [NSData dataWithContentsOfURL:[NSURL fileURLWithPath:location.path]] : nil;
       networkError = [DBTransportBaseClient dBRequestErrorWithErrorData:errorData
                                                             clientError:clientError
                                                              statusCode:statusCode


### PR DESCRIPTION
Fixes https://github.com/dropbox/dropbox-sdk-obj-c/issues/263

[NSData dataWithContentsOfURL:url] will return nil if url is not a file url.