### PR TITLE
Removes debug constants and debug hostname formats

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseConfig.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseConfig.h
@@ -78,6 +78,21 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param appSecret The consumer app secret associated with the app that is integrating with the Dropbox API. Here, app
 /// key is used for querying endpoints the have "app auth" authentication type.
 /// @param userAgent The user agent associated with all networking requests. Used for server logging.
+/// @param hostnameConfig A set of custom hostnames to use for networking requests.
+///
+/// @return An initialized instance.
+- (instancetype)initWithAppKey:(nullable NSString *)appKey
+                     appSecret:(nullable NSString *)appSecret
+                     userAgent:(nullable NSString *)userAgent
+                hostnameConfig:(DBTransportBaseHostnameConfig *)hostnameConfig;
+///
+/// Convenience constructor.
+///
+/// @param appKey The consumer app key associated with the app that is integrating with the Dropbox API. Here, app key
+/// is used for querying endpoints the have "app auth" authentication type.
+/// @param appSecret The consumer app secret associated with the app that is integrating with the Dropbox API. Here, app
+/// key is used for querying endpoints the have "app auth" authentication type.
+/// @param userAgent The user agent associated with all networking requests. Used for server logging.
 /// @param asMemberId An additional authentication header field used when a team app with the appropriate permissions
 /// "performs" user API actions on behalf of a team member.
 ///

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseConfig.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseConfig.m
@@ -20,6 +20,14 @@
   return [self initWithAppKey:appKey appSecret:appSecret userAgent:userAgent asMemberId:nil];
 }
 
+- (instancetype)initWithAppKey:(nullable NSString *)appKey
+                     appSecret:(nullable NSString *)appSecret
+                     userAgent:(nullable NSString *)userAgent
+                hostnameConfig:(DBTransportBaseHostnameConfig *)hostnameConfig
+{
+    return [self initWithAppKey:appKey appSecret:appSecret hostnameConfig:hostnameConfig userAgent:userAgent asMemberId:nil additionalHeaders:nil];
+}
+
 - (instancetype)initWithAppKey:(NSString *)appKey
                      appSecret:(NSString *)appSecret
                      userAgent:(NSString *)userAgent

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseHostnameConfig.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseHostnameConfig.m
@@ -27,18 +27,10 @@
 @implementation DBTransportBaseHostnameConfig
 
 - (instancetype)init {
-  if (!kDBSDKDebug) {
     return [self initWithMeta:@"www.dropbox.com"
                           api:@"api.dropbox.com"
                       content:@"api-content.dropbox.com"
                        notify:@"notify.dropboxapi.com"];
-  } else {
-    return [self initWithMeta:[NSString stringWithFormat:@"meta-%@.dev.corp.dropbox.com", kDBSDKDebugHost]
-                          api:[NSString stringWithFormat:@"api-%@.dev.corp.dropbox.com", kDBSDKDebugHost]
-                      content:[NSString stringWithFormat:@"api-content-%@.dev.corp.dropbox.com", kDBSDKDebugHost]
-                       notify:[NSString stringWithFormat:@"notify-%@.dev.corp.dropboxapi.com", kDBSDKDebugHost]];
-  }
-  return self;
 }
 
 - (instancetype)initWithMeta:(NSString *)meta

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.m
@@ -129,8 +129,7 @@ static DBOAuthManager *s_sharedOAuthManager;
   self = [super init];
   if (self) {
     if (host == nil) {
-      host = !kDBSDKDebug ? @"www.dropbox.com"
-                          : [NSString stringWithFormat:@"meta-%@.dev.corp.dropbox.com", kDBSDKDebugHost];
+      host = @"www.dropbox.com";
     }
 
     _appKey = appKey;

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Resources/DBSDKConstants.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Resources/DBSDKConstants.h
@@ -10,6 +10,4 @@ extern NSString *const kDBSDKVersion;
 extern NSString *const kDBSDKDefaultUserAgentPrefix;
 extern NSString *const kDBSDKForegroundSessionId;
 extern NSString *const kDBSDKBackgroundSessionId;
-extern NSString *const kDBSDKDebugHost;
-extern BOOL const kDBSDKDebug;
 extern NSString *const kDBSDKCSRFKey;

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Resources/DBSDKConstants.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Resources/DBSDKConstants.m
@@ -12,11 +12,4 @@ NSString *const kDBSDKVersion = @"5.0.5";
 NSString *const kDBSDKDefaultUserAgentPrefix = @"OfficialDropboxObjCSDKv2";
 NSString *const kDBSDKForegroundSessionId = @"com.dropbox.dropbox_sdk_obj_c_foreground";
 NSString *const kDBSDKBackgroundSessionId = @"com.dropbox.dropbox_sdk_obj_c_background";
-
-// BEGIN DEBUG CONSTANTS
-BOOL const kDBSDKDebug = NO;           // Should never be `YES` in production
-NSString *const kDBSDKDebugHost = nil; // `"dbdev"`, if using EC, or "{user_name}-dbx"`, if dev box.
-                                       // Should never be non-`nil` in production.
-// END DEBUG CONSTANTS
-
 NSString *const kDBSDKCSRFKey = @"kDBSDKCSRFKeyObjCSDK";


### PR DESCRIPTION
Removes kDBSDKDebugHost and kDBSDKDebug. 

Instead of relying on tooling the overwrite these constants, future clients should pass in debug host names via DBTransportBaseConfig initializer. An additional convenience init was also added to that class.