### PR TITLE
Add sharing tests, add test flake resolving code for specific routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     name: Run Unit tests
     runs-on: macos-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     steps:
       - name: Checkout

--- a/TestObjectiveDropbox/IntegrationTests/TestClasses.m
+++ b/TestObjectiveDropbox/IntegrationTests/TestClasses.m
@@ -1283,6 +1283,9 @@ void MyLog(NSString *format, ...) {
                 [self unshareFolder:^{
                     [self shareFolder:nextTest];
                 }];
+            } else if (error.isRateLimitError) {
+                sleep(error.backoff.unsignedIntValue);
+                [self shareFolder:nextTest];
             } else {
                 [TestFormat abort:error routeError:routeError];
             }

--- a/TestObjectiveDropbox/IntegrationTests/TestClasses.m
+++ b/TestObjectiveDropbox/IntegrationTests/TestClasses.m
@@ -1170,7 +1170,12 @@ void MyLog(NSString *format, ...) {
             if (result) {
                 MyLog(@"%@\n", result);
             } else {
-                [TestFormat abort:networkError routeError:routeError];
+                if (networkError.isRateLimitError) {
+                    sleep(networkError.backoff.unsignedIntValue);
+                    [self listFolderLongpollAndTrigger:nextTest];
+                } else {
+                    [TestFormat abort:networkError routeError:routeError];
+                }
             }
         } queue:[NSOperationQueue new]] setProgressBlock:^(int64_t bytesSent, int64_t totalBytesSent, int64_t totalBytesExpectedToSend) {
             [TestFormat printSentProgress:bytesSent
@@ -1273,7 +1278,14 @@ void MyLog(NSString *format, ...) {
                 [TestFormat abort:error routeError:routeError];
             }
         } else {
-            [TestFormat abort:error routeError:routeError];
+            if(routeError.isBadPath && routeError.badPath.isAlreadyShared) {
+                // prob leftover from another test
+                [self unshareFolder:^{
+                    [self shareFolder:nextTest];
+                }];
+            } else {
+                [TestFormat abort:error routeError:routeError];
+            }
         }
     } queue:[NSOperationQueue new]] setProgressBlock:^(int64_t bytesSent, int64_t totalBytesSent, int64_t totalBytesExpectedToSend) {
         [TestFormat printSentProgress:bytesSent

--- a/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/FileRoutesTests.m
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/FileRoutesTests.m
@@ -3,7 +3,7 @@
 #import <ObjectiveDropboxOfficial/ObjectiveDropboxOfficial.h>
 #import "TestAuthTokenGenerator.h"
 
-static NSString *scopesForFileRoutesTests = @"account_info.read files.content.read files.content.write files.metadata.read files.metadata.write";
+static NSString *scopesForFileRoutesTests = @"account_info.read files.content.read files.content.write files.metadata.read files.metadata.write sharing.write sharing.read";
 
 @interface FileRoutesTests : XCTestCase
 @end
@@ -15,7 +15,7 @@ static NSString *scopesForFileRoutesTests = @"account_info.read files.content.re
     TestData *_testData;
 }
 
-- (void)setUp {
+- (DBUserClient *)createUserClient {
     self.continueAfterFailure = NO;
     // You need an API app with the "Full Dropbox" permission type and at least the scopes in scopesForFileRoutesTests
     // and no team scopes.
@@ -40,11 +40,24 @@ static NSString *scopesForFileRoutesTests = @"account_info.read files.content.re
                                 forceForegroundSession:YES // NO here will cause downloadURL to fail on OSX
                              sharedContainerIdentifier:nil];
 
-    _userClient = [[DBUserClient alloc] initWithAccessToken:fileRoutesTestsAuthToken
+    return [[DBUserClient alloc] initWithAccessToken:fileRoutesTestsAuthToken
         transportConfig:transportConfigFullDropbox];
+}
 
-    _testData = [[TestData alloc] init];
-    _tester = [[DropboxTester alloc] initWithUserClient:_userClient testData:_testData];
+- (void)setUp {
+    self.continueAfterFailure = NO;
+    _userClient = [self createUserClient];
+
+    TestData * data = [[TestData alloc] init];
+    data.teamMemberEmail = [TestAuthTokenGenerator environmentVariableForKey:@"TEAM_MEMBER_EMAIL"];
+    data.teamMemberNewEmail = [TestAuthTokenGenerator environmentVariableForKey:@"NON_TEAM_MEMBER_EMAIL"];
+    data.accountId = [TestAuthTokenGenerator environmentVariableForKey:@"REFRESH_TOKEN_ACCOUNT_ID"];
+    data.accountId2 = [TestAuthTokenGenerator environmentVariableForKey:@"ANY_OTHER_ACCOUNT_ID"];
+    data.accountId3 = [TestAuthTokenGenerator environmentVariableForKey:@"NON_TEAM_MEMBER_ACCOUNT_ID"];
+    data.accountId3Email = data.teamMemberNewEmail;
+    
+    _tester = [[DropboxTester alloc] initWithUserClient:_userClient testData:data];
+    _testData = data;
 }
 
 - (void)tearDown {
@@ -65,7 +78,7 @@ static NSString *scopesForFileRoutesTests = @"account_info.read files.content.re
 
 - (void)testFileRoutes {
     XCTestExpectation *flag = [[XCTestExpectation alloc] init];
-    [_tester testFilesEndpoints:^{
+    [_tester testAllUserAPIEndpoints:^{
         [flag fulfill];
     } asMember:NO];
     XCTWaiterResult result = [XCTWaiter waitForExpectations:@[flag] timeout:60*5];

--- a/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/FileRoutesTests.m
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/FileRoutesTests.m
@@ -76,7 +76,7 @@ static NSString *scopesForFileRoutesTests = @"account_info.read files.content.re
     [self waitForExpectations:@[flag] timeout:30]; // don't need to check result
 }
 
-- (void)testFileRoutes {
+- (void)testAllUserEndpoints {
     XCTestExpectation *flag = [[XCTestExpectation alloc] init];
     [_tester testAllUserAPIEndpoints:^{
         [flag fulfill];

--- a/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/TestAuthTokenGenerator.m
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/TestAuthTokenGenerator.m
@@ -9,6 +9,7 @@
     NSString *value = processInfoDict[key];
     XCTAssertNotNil(value, @"%@ environment variable must exist", key);
     XCTAssertNotEqual(value.length, 0, @"%@ environment variable must be longer than 0", key);
+    XCTAssertFalse([value hasSuffix:@" "], @"%@ environment variable value must not end in whitespace", key);
     return value;
 }
 


### PR DESCRIPTION
- Make the file routes test run all tests, including sharing test. This requires new scopes. I had to remake the refresh token to include the sharing routes
- Add retry for a specific rate limiting
- Add unshare for accounts where the folder is already shared due to a past test run
- Add assert for secrets that end with whitespace