### PR TITLE
Expose inits that allow the clients to be created with access tokens

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/DBTeamClient.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/DBTeamClient.h
@@ -10,6 +10,8 @@
 @class DBTransportDefaultClient;
 @class DBTransportDefaultConfig;
 @protocol DBAccessTokenProvider;
+@class DBAccessToken;
+@class DBOAuthManager;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -78,6 +80,20 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithAccessTokenProvider:(id<DBAccessTokenProvider>)accessTokenProvider
                                    tokenUid:(nullable NSString *)tokenUid
                             transportConfig:(nullable DBTransportDefaultConfig *)transportConfig;
+
+///
+/// Convenience initializer.
+///
+/// @param accessToken An access token object.
+/// @param oauthManager The oauthManager instance.
+/// @param transportConfig A wrapper around the different parameters that can be set to change network calling behavior.
+/// `DBTransportDefaultConfig` offers a number of different constructors to customize networking settings.
+///
+/// @return An initialized instance.
+///
+- (instancetype)initWithAccessToken:(DBAccessToken *)accessToken
+                       oauthManager:(DBOAuthManager *)oauthManager
+                    transportConfig:(nullable DBTransportDefaultConfig *)transportConfig;
 
 /// Designated initializer.
 ///

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/DBTeamClient.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/DBTeamClient.m
@@ -8,6 +8,7 @@
 #import "DBTransportDefaultClient.h"
 #import "DBTransportDefaultConfig.h"
 #import "DBUserClient.h"
+#import "DBOAuthManager+Protected.h"
 
 @implementation DBTeamClient
 
@@ -35,6 +36,21 @@
   DBTransportDefaultClient *transportClient =
       [[DBTransportDefaultClient alloc] initWithAccessTokenProvider:accessTokenProvider
                                                            tokenUid:tokenUid
+                                                    transportConfig:transportConfig];
+  return [self initWithTransportClient:transportClient];
+}
+
+- (instancetype)initWithAccessToken:(DBAccessToken *)accessToken
+                                   oauthManager:(DBOAuthManager *)oauthManager
+                            transportConfig:(DBTransportDefaultConfig *)transportConfig {
+    NSCParameterAssert(oauthManager);
+    NSCParameterAssert(accessToken);
+
+  id<DBAccessTokenProvider> tokenProvider = [oauthManager accessTokenProviderForToken:accessToken];
+
+  DBTransportDefaultClient *transportClient =
+      [[DBTransportDefaultClient alloc] initWithAccessTokenProvider:tokenProvider
+                                                           tokenUid:accessToken.uid
                                                     transportConfig:transportConfig];
   return [self initWithTransportClient:transportClient];
 }

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/DBUserClient.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/DBUserClient.h
@@ -10,6 +10,8 @@
 @class DBTransportDefaultClient;
 @class DBTransportDefaultConfig;
 @protocol DBAccessTokenProvider;
+@class DBAccessToken;
+@class DBOAuthManager;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -78,6 +80,20 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithAccessTokenProvider:(id<DBAccessTokenProvider>)accessTokenProvider
                                    tokenUid:(nullable NSString *)tokenUid
                             transportConfig:(nullable DBTransportDefaultConfig *)transportConfig;
+
+///
+/// Convenience initializer.
+///
+/// @param accessToken An access token object.
+/// @param oauthManager The oauthManager instance.
+/// @param transportConfig A wrapper around the different parameters that can be set to change network calling behavior.
+/// `DBTransportDefaultConfig` offers a number of different constructors to customize networking settings.
+///
+/// @return An initialized instance.
+///
+- (instancetype)initWithAccessToken:(DBAccessToken *)accessToken
+                       oauthManager:(DBOAuthManager *)oauthManager
+                    transportConfig:(nullable DBTransportDefaultConfig *)transportConfig;
 
 /// Designated initializer.
 ///

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/DBUserClient.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/DBUserClient.m
@@ -7,6 +7,7 @@
 #import "DBAccessTokenProvider.h"
 #import "DBTransportDefaultClient.h"
 #import "DBTransportDefaultConfig.h"
+#import "DBOAuthManager+Protected.h"
 
 @implementation DBUserClient
 
@@ -34,6 +35,20 @@
   DBTransportDefaultClient *transportClient =
       [[DBTransportDefaultClient alloc] initWithAccessTokenProvider:accessTokenProvider
                                                            tokenUid:tokenUid
+                                                    transportConfig:transportConfig];
+  return [self initWithTransportClient:transportClient];
+}
+
+- (instancetype)initWithAccessToken:(DBAccessToken *)accessToken
+                                   oauthManager:(DBOAuthManager *)oauthManager
+                            transportConfig:(DBTransportDefaultConfig *)transportConfig {
+  NSCParameterAssert(oauthManager);
+  NSCParameterAssert(accessToken);
+  id<DBAccessTokenProvider> tokenProvider = [oauthManager accessTokenProviderForToken:accessToken];
+
+  DBTransportDefaultClient *transportClient =
+      [[DBTransportDefaultClient alloc] initWithAccessTokenProvider:tokenProvider
+                                                           tokenUid:accessToken.uid
                                                     transportConfig:transportConfig];
   return [self initWithTransportClient:transportClient];
 }

--- a/TestObjectiveDropbox/Podfile.lock
+++ b/TestObjectiveDropbox/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - ObjectiveDropboxOfficial (6.0.1)
+  - ObjectiveDropboxOfficial (6.1.0)
 
 DEPENDENCIES:
   - ObjectiveDropboxOfficial (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  ObjectiveDropboxOfficial: f6357b632e763f3f6bec2df41d9e66372f5fa401
+  ObjectiveDropboxOfficial: b4765572e334d6fc6214b43a7595510324bbbbaa
 
 PODFILE CHECKSUM: 9fd03646bd8426ab0dfe9b4eaa0407fd51d7b8ff
 

--- a/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/FileRoutesTests.m
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/FileRoutesTests.m
@@ -22,7 +22,7 @@
     // Then follow https://dropbox.tech/developers/pkce--what-and-why- to get a refresh token using the PKCE flow
     NSString *apiAppKey = [TestAuthTokenGenerator environmentVariableForKey:@"FULL_DROPBOX_API_APP_KEY"];
 
-    NSString *fileRoutesTestsAuthToken = [TestAuthTokenGenerator
+    DBAccessToken *fileRoutesTestsAuthToken = [TestAuthTokenGenerator
                                           refreshToken:[TestAuthTokenGenerator environmentVariableForKey:@"FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN"]
                                           apiKey:apiAppKey
                                           scopes:[DropboxTester scopesForTests]];
@@ -38,8 +38,8 @@
                                 forceForegroundSession:YES // NO here will cause downloadURL to fail on OSX
                              sharedContainerIdentifier:nil];
 
-    return [[DBUserClient alloc] initWithAccessToken:fileRoutesTestsAuthToken
-        transportConfig:transportConfigFullDropbox];
+    DBOAuthManager *manager = [[DBOAuthManager alloc] initWithAppKey:transportConfigFullDropbox.appKey];
+    return [[DBUserClient alloc] initWithAccessToken:fileRoutesTestsAuthToken oauthManager:manager transportConfig:transportConfigFullDropbox];
 }
 
 - (void)setUp {

--- a/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/TeamRoutesTests.m
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/TeamRoutesTests.m
@@ -34,7 +34,7 @@
     // Then follow https://dropbox.tech/developers/pkce--what-and-why- to get a refresh token using the PKCE flow
 
     NSString *apiAppKey = [TestAuthTokenGenerator environmentVariableForKey:@"FULL_DROPBOX_API_APP_KEY"];
-    NSString *teamRoutesTestsAuthToken = [TestAuthTokenGenerator
+    DBAccessToken *teamRoutesTestsAuthToken = [TestAuthTokenGenerator
                                           refreshToken:[TestAuthTokenGenerator environmentVariableForKey:@"FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN"]
                                           apiKey:apiAppKey
                                           scopes:[DropboxTeamTester scopesForTests]];
@@ -50,7 +50,9 @@
                                 forceForegroundSession:YES // NO here will cause downloadURL to fail on OSX
                              sharedContainerIdentifier:nil];
     
-    return [[DBTeamClient alloc] initWithAccessToken:teamRoutesTestsAuthToken transportConfig:transportConfigFullDropbox];
+    
+    DBOAuthManager *manager = [[DBOAuthManager alloc] initWithAppKey:transportConfigFullDropbox.appKey];
+    return [[DBTeamClient alloc] initWithAccessToken:teamRoutesTestsAuthToken oauthManager:manager transportConfig:transportConfigFullDropbox];
 }
 
 - (void)testTeammemberManagement {

--- a/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/TestAuthTokenGenerator.h
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/TestAuthTokenGenerator.h
@@ -1,8 +1,9 @@
+@class DBAccessToken;
 
 @interface TestAuthTokenGenerator : NSObject
-+ (nonnull NSString *)environmentVariableForKey:(NSString *)key;
++ (nonnull NSString *)environmentVariableForKey:(nonnull NSString *)key;
 
-+ (nullable NSString *)refreshToken:(nullable NSString *)refreshToken
++ (nullable DBAccessToken *)refreshToken:(nullable NSString *)refreshToken
                              apiKey:(nullable NSString *)apiKey
                              scopes:(nonnull NSArray<NSString *>*)scopes;
 @end

--- a/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/TestAuthTokenGenerator.m
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/TestAuthTokenGenerator.m
@@ -14,7 +14,7 @@
 }
 
 // Easy way for all tests to get an auth token for the scopes they use.
-+ (nullable NSString *)refreshToken:(nullable NSString *)refreshToken
++ (nullable DBAccessToken *)refreshToken:(nullable NSString *)refreshToken
                              apiKey:(nullable NSString *)apiKey
                              scopes:(nonnull NSArray<NSString *>*)scopes {
     XCTAssertNotEqual(refreshToken.length, 0, @"Error: refreshToken needs to be set");
@@ -34,7 +34,7 @@
 
     XCTestExpectation *flag = [[XCTestExpectation alloc] init];
     DBOAuthManager *manager = [[DBOAuthManager alloc] initWithAppKey:apiKey];
-    __block NSString *authToken = nil;
+    __block DBAccessToken *authToken = nil;
     [manager refreshAccessToken:defaultToken
                          scopes:scopes
                           queue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0)
@@ -42,7 +42,7 @@
         if(!result.isSuccess) {
             XCTFail(@"Error: failed to refresh access token (%@)", result.errorDescription);
         } else {
-            authToken = result.accessToken.accessToken;
+            authToken = result.accessToken;
         }
         [flag fulfill];
     }];


### PR DESCRIPTION
So that short lived tokens can be used to create the user and team clients