### PR TITLE
Fix disable_signup parameter conditional

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.m
@@ -137,7 +137,7 @@ static DBOAuthManager *s_sharedOAuthManager;
     _cancelURL = [NSURL URLWithString:[NSString stringWithFormat:@"db-%@://2/cancel", _appKey]];
     _host = host;
     _urls = [NSMutableArray arrayWithObjects:_redirectURL, nil];
-#ifdef TARGET_OS_OSX
+#if TARGET_OS_OSX
     _disableSignup = NO;
 #else
     _disableSignup = YES;


### PR DESCRIPTION
TARGET_OS_OSX is defined even in situations in which it's not the target OS. We want `#if TARGET_OS_OSX` for this check.