### PR TITLE
Fix compiler warning

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBAccessTokenProviderImpl.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBAccessTokenProviderImpl.m
@@ -82,7 +82,7 @@
 /// Refresh if it's about to expire (5 minutes from expiration) or already expired.
 - (BOOL)db_shouldRefresh {
   NSTimeInterval expirationTimestamp = _token.tokenExpirationTimestamp;
-  if (!expirationTimestamp) {
+  if (expirationTimestamp == 0) {
     return NO;
   }
 


### PR DESCRIPTION
The warning is `Implicit conversion turns floating-point number into integer: 'NSTimeInterval' (aka 'double') to 'bool'` - compare to zero rather than doing coercion.