### PR TITLE
Prepare for Xcode 14

### DIFF
--- a/ObjectiveDropboxOfficial.podspec
+++ b/ObjectiveDropboxOfficial.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   
   s.osx.deployment_target = '10.10'
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '11.0'
  
   s.public_header_files = 'Source/ObjectiveDropboxOfficial/Shared/**/*.h', 'Source/ObjectiveDropboxOfficial/Headers/Umbrella/*.h'
   s.osx.public_header_files = 'Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/**/*.h'

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ NOTE: Please do not rely on `master` in production. Please instead use one of ou
 
 ## System requirements
 
-- iOS 9.0+
+- iOS 11.0+
 - macOS 10.10+
 - Xcode 8+ (11.0+ if you use Carthage)
 

--- a/TestObjectiveDropbox/Podfile
+++ b/TestObjectiveDropbox/Podfile
@@ -1,7 +1,7 @@
 use_frameworks!
 
 target "TestObjectiveDropbox_iOS" do
-    platform :ios, '9.0'
+    platform :ios, '11.0'
     pod 'ObjectiveDropboxOfficial', :path => '../'
     target "TestObjectiveDropbox_iOSTests" do
         pod 'ObjectiveDropboxOfficial', :path => '../'

--- a/TestObjectiveDropbox/Podfile.lock
+++ b/TestObjectiveDropbox/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - ObjectiveDropboxOfficial (6.2.3)
+  - ObjectiveDropboxOfficial (6.3.2)
 
 DEPENDENCIES:
   - ObjectiveDropboxOfficial (from `../`)
@@ -9,8 +9,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  ObjectiveDropboxOfficial: fe206ce8c0bc49976c249d472db7fdbc53ebbd53
+  ObjectiveDropboxOfficial: a3981e58f087e056b26d02dfeb994d6af21b980f
 
-PODFILE CHECKSUM: 9fd03646bd8426ab0dfe9b4eaa0407fd51d7b8ff
+PODFILE CHECKSUM: 34ac610e6620890c744476957559b5cef359d526
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/TestObjectiveDropbox/TestObjectiveDropbox.xcodeproj/project.pbxproj
+++ b/TestObjectiveDropbox/TestObjectiveDropbox.xcodeproj/project.pbxproj
@@ -353,7 +353,7 @@
 		F27BA7FC1D63BBA100FB7864 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1140;
+				LastUpgradeCheck = 1400;
 				ORGANIZATIONNAME = Dropbox;
 				TargetAttributes = {
 					0C1FE64F2603031100D879BB = {
@@ -862,7 +862,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -912,7 +912,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -931,7 +931,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = NX6T6UBSFF;
 				INFOPLIST_FILE = TestObjectiveDropbox_iOS/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dropbox.TestObjectiveDropbox-iOS-Test";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -949,7 +949,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = NX6T6UBSFF;
 				INFOPLIST_FILE = TestObjectiveDropbox_iOS/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dropbox.TestObjectiveDropbox-iOS-Test";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/TestObjectiveDropbox/TestObjectiveDropbox.xcodeproj/xcshareddata/xcschemes/TestObjectiveDropbox_iOS.xcscheme
+++ b/TestObjectiveDropbox/TestObjectiveDropbox.xcodeproj/xcshareddata/xcschemes/TestObjectiveDropbox_iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TestObjectiveDropbox/TestObjectiveDropbox.xcodeproj/xcshareddata/xcschemes/TestObjectiveDropbox_macOS.xcscheme
+++ b/TestObjectiveDropbox/TestObjectiveDropbox.xcodeproj/xcshareddata/xcschemes/TestObjectiveDropbox_macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TestObjectiveDropbox/TestObjectiveDropbox_iOS/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_iOS/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,92 +2,97 @@
   "images" : [
     {
       "idiom" : "iphone",
-      "size" : "20x20",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "20x20",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "29x29"
     },
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "29x29"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "40x40"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "40x40"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "60x60"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "60x60"
     },
     {
       "idiom" : "ipad",
-      "size" : "20x20",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "20x20"
     },
     {
       "idiom" : "ipad",
-      "size" : "20x20",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
       "idiom" : "ipad",
-      "size" : "29x29",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "29x29"
     },
     {
       "idiom" : "ipad",
-      "size" : "29x29",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "29x29"
     },
     {
       "idiom" : "ipad",
-      "size" : "40x40",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "40x40"
     },
     {
       "idiom" : "ipad",
-      "size" : "40x40",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "40x40"
     },
     {
       "idiom" : "ipad",
-      "size" : "76x76",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "76x76"
     },
     {
       "idiom" : "ipad",
-      "size" : "76x76",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "76x76"
     },
     {
       "idiom" : "ipad",
-      "size" : "83.5x83.5",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }


### PR DESCRIPTION
Silence warnings on Xcode 14 by:
- Declining automatic project updates in TestObjectiveDropbox
- Bumping deployment targets from 9.0 to 11.0 (The newest Xcode doesn't support building for below iOS 11.0, and come next spring, App Store Connect will require the latest Xcode)
- Xcode now seems to sort JSON in xcassets–the sorting changes are included in this diff as well