### PR TITLE
Optimize ascii encoding.

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseClient.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseClient.m
@@ -206,16 +206,13 @@
 }
 
 + (NSString *)asciiEscapeWithString:(NSString *)string {
-  NSMutableString *result = [[NSMutableString alloc] init];
-  for (NSUInteger i = 0; i < string.length; i++) {
-    NSString *substring = [string substringWithRange:NSMakeRange(i, 1)];
-    if ([substring canBeConvertedToEncoding:NSASCIIStringEncoding]) {
-      [result appendString:substring];
-    } else {
-      [result appendFormat:@"\\u%04x", [string characterAtIndex:i]];
+    // if the string is already ascii, return immediately
+    if ([string canBeConvertedToEncoding:NSASCIIStringEncoding]) {
+        return [string copy];
     }
-  }
-  return result;
+    
+    const char *encoded = [string cStringUsingEncoding:NSNonLossyASCIIStringEncoding];
+    return [[NSString alloc] initWithCString:encoded encoding:NSASCIIStringEncoding];
 }
 
 + (DBRequestError *)dBRequestErrorWithErrorData:(NSData *)errorData

--- a/TestObjectiveDropbox/Podfile.lock
+++ b/TestObjectiveDropbox/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - ObjectiveDropboxOfficial (6.3.2)
+  - ObjectiveDropboxOfficial (7.0.0)
 
 DEPENDENCIES:
   - ObjectiveDropboxOfficial (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  ObjectiveDropboxOfficial: a3981e58f087e056b26d02dfeb994d6af21b980f
+  ObjectiveDropboxOfficial: cf39e37372f59c270aad869604dce20f11b877f5
 
 PODFILE CHECKSUM: 34ac610e6620890c744476957559b5cef359d526
 

--- a/TestObjectiveDropbox/TestObjectiveDropbox.xcodeproj/project.pbxproj
+++ b/TestObjectiveDropbox/TestObjectiveDropbox.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		0C8B8AE1260B008E00B3522B /* TestAuthTokenGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C8B8ADF260B008D00B3522B /* TestAuthTokenGenerator.m */; };
 		1BC94474BAF7A7BB8B521568 /* Pods_TestObjectiveDropbox_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E61D8320FDA365F90A8004D /* Pods_TestObjectiveDropbox_iOS.framework */; };
 		7D591876B62B5B205035C8E9 /* Pods_TestObjectiveDropbox_iOS_TestObjectiveDropbox_iOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D55835BD704F9EAAB8E89FB /* Pods_TestObjectiveDropbox_iOS_TestObjectiveDropbox_iOSTests.framework */; };
+		85BF03CE2981C2B900350891 /* TestAsciiEncoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 85BF03CD2981C2B900350891 /* TestAsciiEncoding.m */; };
 		BCDD1285CB9359806B4DEF2A /* Pods_TestObjectiveDropbox_macOS_TestObjectiveDropbox_macOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B0A70443E73CD2045DC5577 /* Pods_TestObjectiveDropbox_macOS_TestObjectiveDropbox_macOSTests.framework */; };
 		CB3E70120855B4B1ABCFF719 /* Pods_TestObjectiveDropbox_macOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EF03FDC09CC9F1D2179AB000 /* Pods_TestObjectiveDropbox_macOS.framework */; };
 		F23681561DEF647900D523C5 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F23681551DEF647900D523C5 /* AppDelegate.m */; };
@@ -69,6 +70,7 @@
 		6874E63CE61C80116147AFB0 /* Pods-TestObjectiveDropbox_macOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestObjectiveDropbox_macOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-TestObjectiveDropbox_macOS/Pods-TestObjectiveDropbox_macOS.release.xcconfig"; sourceTree = "<group>"; };
 		6B0A70443E73CD2045DC5577 /* Pods_TestObjectiveDropbox_macOS_TestObjectiveDropbox_macOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TestObjectiveDropbox_macOS_TestObjectiveDropbox_macOSTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		73F1A4955BD1AAF3362871A6 /* Pods-TestObjectiveDropbox_iOS-TestObjectiveDropbox_iOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestObjectiveDropbox_iOS-TestObjectiveDropbox_iOSTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TestObjectiveDropbox_iOS-TestObjectiveDropbox_iOSTests/Pods-TestObjectiveDropbox_iOS-TestObjectiveDropbox_iOSTests.debug.xcconfig"; sourceTree = "<group>"; };
+		85BF03CD2981C2B900350891 /* TestAsciiEncoding.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestAsciiEncoding.m; sourceTree = "<group>"; };
 		E9403DCD149530530F654EE7 /* Pods-TestObjectiveDropbox_iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestObjectiveDropbox_iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-TestObjectiveDropbox_iOS/Pods-TestObjectiveDropbox_iOS.release.xcconfig"; sourceTree = "<group>"; };
 		EF03FDC09CC9F1D2179AB000 /* Pods_TestObjectiveDropbox_macOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TestObjectiveDropbox_macOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F23681521DEF647900D523C5 /* TestObjectiveDropbox_macOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestObjectiveDropbox_macOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -162,6 +164,7 @@
 				0C40FC01260533B300D07F24 /* TeamRoutesTests.m */,
 				0C8B8ADF260B008D00B3522B /* TestAuthTokenGenerator.m */,
 				0C8B8AE6260B016200B3522B /* TestAuthTokenGenerator.h */,
+				85BF03CD2981C2B900350891 /* TestAsciiEncoding.m */,
 			);
 			path = TestObjectiveDropbox_iOSTests;
 			sourceTree = "<group>";
@@ -611,6 +614,7 @@
 			files = (
 				0C8B8AE0260B008E00B3522B /* TestAuthTokenGenerator.m in Sources */,
 				0C40FC02260533B300D07F24 /* TeamRoutesTests.m in Sources */,
+				85BF03CE2981C2B900350891 /* TestAsciiEncoding.m in Sources */,
 				0C1D1D6D26005BF800C88B6F /* FileRoutesTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/TestAsciiEncoding.m
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/TestAsciiEncoding.m
@@ -1,0 +1,65 @@
+#import <XCTest/XCTest.h>
+#import <ObjectiveDropboxOfficial/ObjectiveDropboxOfficial.h>
+
+@interface DBTransportBaseClient (Tests)
++ (NSString *)asciiEscapeWithString:(NSString *)string;
+@end
+
+@interface TestAsciiEncoding : XCTestCase
+
+@end
+
+@implementation TestAsciiEncoding
+
+// This was the prior method to ascii escape for comparison purposes.
++ (NSString *)old_asciiEscapeWithString:(NSString *)string {
+  NSMutableString *result = [[NSMutableString alloc] init];
+  for (NSUInteger i = 0; i < string.length; i++) {
+    NSString *substring = [string substringWithRange:NSMakeRange(i, 1)];
+    if ([substring canBeConvertedToEncoding:NSASCIIStringEncoding]) {
+      [result appendString:substring];
+    } else {
+      [result appendFormat:@"\\u%04x", [string characterAtIndex:i]];
+    }
+  }
+  return result;
+}
+
+- (void)setUp {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
++ (NSDictionary<NSString *, NSString *> *)testStrings {
+    return @{
+        @"hello": @"hello",
+        @"": @"",
+        @"こんにちは": @"\\u3053\\u3093\\u306b\\u3061\\u306f",
+        @"this has a clustered flag 🇺🇸": @"this has a clustered flag \\ud83c\\uddfa\\ud83c\\uddf8",
+        @"this is a big emoji 👩‍👩‍👧‍👦": @"this is a big emoji \\ud83d\\udc69\\u200d\\ud83d\\udc69\\u200d\\ud83d\\udc67\\u200d\\ud83d\\udc66",
+        @"🍺": @"\\ud83c\\udf7a",
+        @"this\nhas some whitespace": @"this\nhas some whitespace"
+    };
+}
+
+- (void)testEncodings {
+    NSDictionary *testStrings = [TestAsciiEncoding testStrings];
+    for (NSString *str in [testStrings allKeys]) {
+        NSString *lhs = [DBTransportBaseClient asciiEscapeWithString:str];
+        NSString *rhs = testStrings[str];
+        XCTAssertTrue([lhs isEqualToString:rhs]);
+    }
+}
+
+- (void)testAgainstOldImplementation {
+    NSDictionary *testStrings = [TestAsciiEncoding testStrings];
+    for (NSString *str in [testStrings allKeys]) {
+        NSString *lhs = [DBTransportBaseClient asciiEscapeWithString:str];
+        NSString *rhs = [TestAsciiEncoding old_asciiEscapeWithString:str];
+        XCTAssertTrue([lhs isEqualToString:rhs]);
+    }
+}
+@end


### PR DESCRIPTION
It turns out this method is both a) an extremely unoptimized way to do what it is trying to do and b) possibly not accurate in addressing grapheme clusters. Delegate this functionality to Foundation instead.