### PR TITLE
Fix new ASCII encoder, and put behind a flag for testing.

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseClient.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseClient.h
@@ -40,6 +40,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Additional HTTP headers to be injected into each client request.
 @property (nonatomic, readonly, copy, nullable) NSDictionary<NSString *, NSString *> *additionalHeaders;
 
+/// Set YES to use a faster, experimental ASCII encoding implementation. Default = NO.
+@property (atomic, class) BOOL useFastAsciiEncoding;
+
 ///
 /// Convenience initializer.
 ///

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseClient.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseClient.m
@@ -24,6 +24,17 @@
 
 @implementation DBTransportBaseClient
 
+static BOOL kUseFastAsciiEncoding;
+static NSLock *kAsciiEscapeSelectorLock;
+
++ (void)initialize {
+  [super initialize];
+  if (self == [DBTransportBaseClient class]) {
+    kUseFastAsciiEncoding = NO;
+    kAsciiEscapeSelectorLock = [[NSLock alloc] init];
+  }
+}
+
 - (instancetype)initWithAccessToken:(NSString *)accessToken
                            tokenUid:(NSString *)tokenUid
                     transportConfig:(DBTransportBaseConfig *)transportConfig {
@@ -205,14 +216,68 @@
   return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
 }
 
++ (BOOL)useFastAsciiEncoding {
+  BOOL result;
+  
+  [kAsciiEscapeSelectorLock lock];
+  result = kUseFastAsciiEncoding;
+  [kAsciiEscapeSelectorLock unlock];
+  return result;
+}
+
++ (void)setUseFastAsciiEncoding:(BOOL)useFastAsciiEncoding {
+  [kAsciiEscapeSelectorLock lock];
+  kUseFastAsciiEncoding = useFastAsciiEncoding;
+  [kAsciiEscapeSelectorLock unlock];
+}
+
 + (NSString *)asciiEscapeWithString:(NSString *)string {
-    // if the string is already ascii, return immediately
-    if ([string canBeConvertedToEncoding:NSASCIIStringEncoding]) {
-        return [string copy];
+  BOOL useFastEncoding = NO;
+  [kAsciiEscapeSelectorLock lock];
+  useFastEncoding = kUseFastAsciiEncoding;
+  [kAsciiEscapeSelectorLock unlock];
+  
+  NSString* result;
+  if (useFastEncoding) {
+    result = [self fast_asciiEscapeWithString:string];
+  } else {
+    result = [self slow_asciiEscapeWithString:string];
+  }
+  return result;
+}
+
++ (NSString *)slow_asciiEscapeWithString:(NSString *)string {
+  NSMutableString *result = [[NSMutableString alloc] init];
+  for (NSUInteger i = 0; i < string.length; i++) {
+    NSString *substring = [string substringWithRange:NSMakeRange(i, 1)];
+    if ([substring canBeConvertedToEncoding:NSASCIIStringEncoding]) {
+      [result appendString:substring];
+    } else {
+      [result appendFormat:@"\\u%04x", [string characterAtIndex:i]];
     }
-    
-    const char *encoded = [string cStringUsingEncoding:NSNonLossyASCIIStringEncoding];
-    return [[NSString alloc] initWithCString:encoded encoding:NSASCIIStringEncoding];
+  }
+  return result;
+}
+
++ (NSString *)fast_asciiEscapeWithString:(NSString *)string {
+  // if the string is already ascii, return immediately
+  if ([string canBeConvertedToEncoding:NSASCIIStringEncoding]) {
+    return [string copy];
+  }
+  
+  NSMutableString *encoded = [NSMutableString stringWithCapacity:[string length]];
+  for(int i = 0; i < [string length]; i++) {
+    unichar character = [string characterAtIndex:i];
+    // Anything that is raw ASCII (not extended) can be applied as a regular old character.
+    if (character < 128) {
+      [encoded appendFormat:@"%c", character];
+    } else {
+      // Everything else needs to be encoded, including the extended ascii set.
+      [encoded appendFormat:@"\\u%04x", character];
+    }
+  }
+  
+  return [encoded copy];
 }
 
 + (DBRequestError *)dBRequestErrorWithErrorData:(NSData *)errorData

--- a/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/TestAsciiEncoding.m
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/TestAsciiEncoding.m
@@ -3,6 +3,8 @@
 
 @interface DBTransportBaseClient (Tests)
 + (NSString *)asciiEscapeWithString:(NSString *)string;
++ (NSString *)fast_asciiEscapeWithString:(NSString *)string;
++ (NSString *)slow_asciiEscapeWithString:(NSString *)string;
 @end
 
 @interface TestAsciiEncoding : XCTestCase
@@ -10,20 +12,6 @@
 @end
 
 @implementation TestAsciiEncoding
-
-// This was the prior method to ascii escape for comparison purposes.
-+ (NSString *)old_asciiEscapeWithString:(NSString *)string {
-  NSMutableString *result = [[NSMutableString alloc] init];
-  for (NSUInteger i = 0; i < string.length; i++) {
-    NSString *substring = [string substringWithRange:NSMakeRange(i, 1)];
-    if ([substring canBeConvertedToEncoding:NSASCIIStringEncoding]) {
-      [result appendString:substring];
-    } else {
-      [result appendFormat:@"\\u%04x", [string characterAtIndex:i]];
-    }
-  }
-  return result;
-}
 
 - (void)setUp {
     // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -41,14 +29,40 @@
         @"this has a clustered flag 🇺🇸": @"this has a clustered flag \\ud83c\\uddfa\\ud83c\\uddf8",
         @"this is a big emoji 👩‍👩‍👧‍👦": @"this is a big emoji \\ud83d\\udc69\\u200d\\ud83d\\udc69\\u200d\\ud83d\\udc67\\u200d\\ud83d\\udc66",
         @"🍺": @"\\ud83c\\udf7a",
-        @"this\nhas some whitespace": @"this\nhas some whitespace"
+        @"this\nhas some whitespace": @"this\nhas some whitespace",
+        @"héllø wörld": @"h\\u00e9ll\\u00f8 w\\u00f6rld"
     };
+}
+
+- (void)testEveryUnichar {
+    for (unsigned short i=0; i < ((unsigned short)-1); i++) {
+        unichar myChar = (unichar)i;
+        NSString *charString = [[NSString alloc] initWithCharacters:&myChar length:1];
+        NSString *lhs = [DBTransportBaseClient slow_asciiEscapeWithString:charString];
+        NSString *rhs = [DBTransportBaseClient fast_asciiEscapeWithString:charString];
+        XCTAssertTrue([lhs isEqualToString:rhs]);
+    }
+}
+
+- (void)testEscapeWithString {
+    NSDictionary *testStrings = [TestAsciiEncoding testStrings];
+    dispatch_block_t testBlock = ^{
+        for (NSString *str in [testStrings allKeys]) {
+            NSString *lhs = [DBTransportBaseClient asciiEscapeWithString:str];
+            NSString *rhs = testStrings[str];
+            XCTAssertTrue([lhs isEqualToString:rhs]);
+        }
+    };
+    
+    testBlock();
+    [DBTransportBaseClient setUseFastAsciiEncoding:YES];
+    testBlock();
 }
 
 - (void)testEncodings {
     NSDictionary *testStrings = [TestAsciiEncoding testStrings];
     for (NSString *str in [testStrings allKeys]) {
-        NSString *lhs = [DBTransportBaseClient asciiEscapeWithString:str];
+        NSString *lhs = [DBTransportBaseClient fast_asciiEscapeWithString:str];
         NSString *rhs = testStrings[str];
         XCTAssertTrue([lhs isEqualToString:rhs]);
     }
@@ -57,8 +71,8 @@
 - (void)testAgainstOldImplementation {
     NSDictionary *testStrings = [TestAsciiEncoding testStrings];
     for (NSString *str in [testStrings allKeys]) {
-        NSString *lhs = [DBTransportBaseClient asciiEscapeWithString:str];
-        NSString *rhs = [TestAsciiEncoding old_asciiEscapeWithString:str];
+        NSString *lhs = [DBTransportBaseClient slow_asciiEscapeWithString:str];
+        NSString *rhs = [DBTransportBaseClient fast_asciiEscapeWithString:str];
         XCTAssertTrue([lhs isEqualToString:rhs]);
     }
 }


### PR DESCRIPTION
The original update to the ASCII encoder missed a key issue: the space between codepoints 128 -> 256 were encoded by Apple's encoder as octal. This PR corrects this with more tests, a new implementation that covers this case, and an atomically switchable implementation to toggle between them for greater safety in testing. To enable:

```
DBBaseTransportClient.useFastAsciiEncoding = YES;
```