### PR TITLE
Fix warning introduced by dropbox#366.

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseClient.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseClient.m
@@ -266,7 +266,7 @@ static NSLock *kAsciiEscapeSelectorLock;
   }
   
   NSMutableString *encoded = [NSMutableString stringWithCapacity:[string length]];
-  for(int i = 0; i < [string length]; i++) {
+  for (NSUInteger i = 0; i < [string length]; i++) {
     unichar character = [string characterAtIndex:i];
     // Anything that is raw ASCII (not extended) can be applied as a regular old character.
     if (character < 128) {


### PR DESCRIPTION
The podfile keeps warnings squashed, so this was missed in my testing.