### PR TITLE
Use correct DBRequestErrorTag on access errors

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBRequestErrors.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBRequestErrors.m
@@ -305,7 +305,7 @@
                      errorContent:(NSString *)errorContent
                       userMessage:(DBLocalizedUserMessage *)userMessage
             structuredAccessError:(DBAUTHAccessError *)structuredAccessError {
-  return [self init:DBRequestErrorAuth
+  return [self init:DBRequestErrorAccess
                      requestId:requestId
                     statusCode:statusCode
                   errorContent:errorContent


### PR DESCRIPTION
[An old commit](https://github.com/dropbox/dropbox-sdk-obj-c/commit/6bea27d9e3c7a938e16ad524da01072941e7f049) made a likely copy and paste error when adding handling for 403 access errors, tagging them instead as auth errors.