### PR TITLE
Remove integration tests for deprecated routes and replace if replacement is public

### DIFF
--- a/TestObjectiveDropbox/IntegrationTests/TestClasses.h
+++ b/TestObjectiveDropbox/IntegrationTests/TestClasses.h
@@ -154,10 +154,6 @@
 - (void)linkedAppsListMemberLinkedApps:(void (^_Nonnull)(void))nextTest;
 - (void)linkedAppsListMembersLinkedApps:(void (^_Nonnull)(void))nextTest;
 - (void)getInfo:(void (^_Nonnull)(void))nextTest;
-- (void)reportsGetActivity:(void (^_Nonnull)(void))nextTest;
-- (void)reportsGetDevices:(void (^_Nonnull)(void))nextTest;
-- (void)reportsGetMembership:(void (^_Nonnull)(void))nextTest;
-- (void)reportsGetStorage:(void (^_Nonnull)(void))nextTest;
 
 // TeamMemberManagement
 
@@ -171,6 +167,7 @@
 - (void)membersAdd:(void (^_Nonnull)(void))nextTest;
 - (void)membersGetInfo:(void (^_Nonnull)(void))nextTest;
 - (void)membersList:(void (^_Nonnull)(void))nextTest;
+- (void)membersListDevices:(void (^_Nonnull)(void))nextTest;
 - (void)membersSendWelcomeEmail:(void (^_Nonnull)(void))nextTest;
 - (void)membersSetAdminPermissions:(void (^_Nonnull)(void))nextTest;
 - (void)membersSetProfile:(void (^_Nonnull)(void))nextTest;

--- a/TestObjectiveDropbox/IntegrationTests/TestClasses.m
+++ b/TestObjectiveDropbox/IntegrationTests/TestClasses.m
@@ -310,20 +310,8 @@ void MyLog(NSString *format, ...) {
         [TestFormat printTestEnd];
         nextTest(teamTests);
     };
-    void (^reportsGetStorage)(void) = ^{
-        [teamTests reportsGetStorage:end];
-    };
-    void (^reportsGetMembership)(void) = ^{
-        [teamTests reportsGetMembership:reportsGetStorage];
-    };
-    void (^reportsGetDevices)(void) = ^{
-        [teamTests reportsGetDevices:reportsGetMembership];
-    };
-    void (^reportsGetActivity)(void) = ^{
-        [teamTests reportsGetActivity:reportsGetDevices];
-    };
     void (^getInfo)(void) = ^{
-        [teamTests getInfo:reportsGetActivity];
+        [teamTests getInfo:end];
     };
     void (^linkedAppsListMembersLinkedApps)(void) = ^{
         [teamTests linkedAppsListMembersLinkedApps:getInfo];
@@ -371,8 +359,11 @@ void MyLog(NSString *format, ...) {
     void (^membersList)(void) = ^{
         [teamTests membersList:membersSendWelcomeEmail];
     };
+    void (^membersListDevices)(void) = ^{
+        [teamTests membersListDevices:membersList];
+    };
     void (^membersGetInfo)(void) = ^{
-        [teamTests membersGetInfo:membersList];
+        [teamTests membersGetInfo:membersListDevices];
     };
     void (^membersAdd)(void) = ^{
         [teamTests membersAdd:membersGetInfo];
@@ -1815,86 +1806,6 @@ void MyLog(NSString *format, ...) {
     }];
 }
 
-- (void)reportsGetActivity:(void (^)(void))nextTest {
-    [TestFormat printSubTestBegin:NSStringFromSelector(_cmd)];
-    NSCalendar *calendar = [NSCalendar currentCalendar];
-    NSDate *twoDaysAgo = [calendar dateByAddingUnit:NSCalendarUnitDay value:-2 toDate:[NSDate new] options:0];
-    [[[_tester.team reportsGetActivity:twoDaysAgo endDate:[NSDate new]]
-      setResponseBlock:^(DBTEAMGetActivityReport *result, DBTEAMDateRangeError *routeError, DBRequestError *error) {
-        if (result) {
-            MyLog(@"%@\n", result);
-            [TestFormat printSubTestEnd:NSStringFromSelector(_cmd)];
-            nextTest();
-        } else {
-            [TestFormat abort:error routeError:routeError];
-        }
-    } queue:[NSOperationQueue new]] setProgressBlock:^(int64_t bytesSent, int64_t totalBytesSent, int64_t totalBytesExpectedToSend) {
-        [TestFormat printSentProgress:bytesSent
-                       totalBytesSent:totalBytesSent
-             totalBytesExpectedToSend:totalBytesExpectedToSend];
-    }];
-}
-
-- (void)reportsGetDevices:(void (^)(void))nextTest {
-    [TestFormat printSubTestBegin:NSStringFromSelector(_cmd)];
-    NSCalendar *calendar = [NSCalendar currentCalendar];
-    NSDate *twoDaysAgo = [calendar dateByAddingUnit:NSCalendarUnitDay value:-2 toDate:[NSDate new] options:0];
-    [[[_tester.team reportsGetDevices:twoDaysAgo endDate:[NSDate new]]
-      setResponseBlock:^(DBTEAMGetDevicesReport *result, DBTEAMDateRangeError *routeError, DBRequestError *error) {
-        if (result) {
-            MyLog(@"%@\n", result);
-            [TestFormat printSubTestEnd:NSStringFromSelector(_cmd)];
-            nextTest();
-        } else {
-            [TestFormat abort:error routeError:routeError];
-        }
-    } queue:[NSOperationQueue new]] setProgressBlock:^(int64_t bytesSent, int64_t totalBytesSent, int64_t totalBytesExpectedToSend) {
-        [TestFormat printSentProgress:bytesSent
-                       totalBytesSent:totalBytesSent
-             totalBytesExpectedToSend:totalBytesExpectedToSend];
-    }];
-}
-
-- (void)reportsGetMembership:(void (^)(void))nextTest {
-    [TestFormat printSubTestBegin:NSStringFromSelector(_cmd)];
-    NSCalendar *calendar = [NSCalendar currentCalendar];
-    NSDate *twoDaysAgo = [calendar dateByAddingUnit:NSCalendarUnitDay value:-2 toDate:[NSDate new] options:0];
-    [[[_tester.team reportsGetMembership:twoDaysAgo endDate:[NSDate new]]
-      setResponseBlock:^(DBTEAMGetMembershipReport *result, DBTEAMDateRangeError *routeError, DBRequestError *error) {
-        if (result) {
-            MyLog(@"%@\n", result);
-            [TestFormat printSubTestEnd:NSStringFromSelector(_cmd)];
-            nextTest();
-        } else {
-            [TestFormat abort:error routeError:routeError];
-        }
-    } queue:[NSOperationQueue new]] setProgressBlock:^(int64_t bytesSent, int64_t totalBytesSent, int64_t totalBytesExpectedToSend) {
-        [TestFormat printSentProgress:bytesSent
-                       totalBytesSent:totalBytesSent
-             totalBytesExpectedToSend:totalBytesExpectedToSend];
-    }];
-}
-
-- (void)reportsGetStorage:(void (^)(void))nextTest {
-    [TestFormat printSubTestBegin:NSStringFromSelector(_cmd)];
-    NSCalendar *calendar = [NSCalendar currentCalendar];
-    NSDate *twoDaysAgo = [calendar dateByAddingUnit:NSCalendarUnitDay value:-2 toDate:[NSDate new] options:0];
-    [[[_tester.team reportsGetStorage:twoDaysAgo endDate:[NSDate new]]
-      setResponseBlock:^(DBTEAMGetStorageReport *result, DBTEAMDateRangeError *routeError, DBRequestError *error) {
-        if (result) {
-            MyLog(@"%@\n", result);
-            [TestFormat printSubTestEnd:NSStringFromSelector(_cmd)];
-            nextTest();
-        } else {
-            [TestFormat abort:error routeError:routeError];
-        }
-    } queue:[NSOperationQueue new]] setProgressBlock:^(int64_t bytesSent, int64_t totalBytesSent, int64_t totalBytesExpectedToSend) {
-        [TestFormat printSentProgress:bytesSent
-                       totalBytesSent:totalBytesSent
-             totalBytesExpectedToSend:totalBytesExpectedToSend];
-    }];
-}
-
 /**
  Permission: TEAM member management
  */
@@ -2173,6 +2084,25 @@ void MyLog(NSString *format, ...) {
             [TestFormat abort:error routeError:routeError];
         }
     } queue:[NSOperationQueue new]] setProgressBlock:^(int64_t bytesSent, int64_t totalBytesSent, int64_t totalBytesExpectedToSend) {
+        [TestFormat printSentProgress:bytesSent
+                       totalBytesSent:totalBytesSent
+             totalBytesExpectedToSend:totalBytesExpectedToSend];
+    }];
+}
+
+- (void)membersListDevices:(void (^)(void))nextTest {
+    [TestFormat printSubTestBegin:NSStringFromSelector(_cmd)];
+
+    [[[_tester.team devicesListMembersDevices]
+     setResponseBlock:^(DBTEAMListMembersDevicesResult *result, DBTEAMListMembersDevicesError *routeError, DBRequestError *error) {
+        if (result) {
+            MyLog(@"%@\n", result);
+            [TestFormat printSubTestEnd:NSStringFromSelector(_cmd)];
+            nextTest();
+        } else {
+            [TestFormat abort:error routeError:routeError];
+        }
+    }  queue:[NSOperationQueue new]] setProgressBlock:^(int64_t bytesSent, int64_t totalBytesSent, int64_t totalBytesExpectedToSend) {
         [TestFormat printSentProgress:bytesSent
                        totalBytesSent:totalBytesSent
              totalBytesExpectedToSend:totalBytesExpectedToSend];


### PR DESCRIPTION
These four routes were deprecated and the server has started returning bad input errors. This PR removes them and replace them with equivalent routes if they publicly exist.