### PR TITLE
[ObjectiveDropbox] Update DBTransportBaseHostnameConfig with downloadContentHost

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseHostnameConfig.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseHostnameConfig.h
@@ -30,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, copy) NSString *meta;
 @property (nonatomic, readonly, copy) NSString *api;
 @property (nonatomic, readonly, copy) NSString *content;
+@property (nonatomic, readonly, copy) NSString *downloadContent;
 @property (nonatomic, readonly, copy) NSString *notify;
 
 ///
@@ -45,11 +46,12 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param meta the hostname to metaserver
 /// @param api the hostname to api server
 /// @param content the hostname to content server
+/// @param downloadContent the hostname to content server for download style
 /// @param notify the hostname to notify server
 ///
 /// @return An initialized instance with the provided hostname configuration
 ///
-- (instancetype)initWithMeta:(NSString *)meta api:(NSString *)api content:(NSString *)content notify:(NSString *)notify;
+- (instancetype)initWithMeta:(NSString *)meta api:(NSString *)api content:(NSString *)content downloadContent:(NSString *)downloadContent notify:(NSString *)notify;
 
 ///
 /// Returns the prefix to use for API calls to the given route type.

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseHostnameConfig.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseHostnameConfig.m
@@ -41,8 +41,19 @@
     _meta = meta;
     _api = api;
     _content = content;
+    _downloadContent = content;
     _notify = notify;
   }
+  return self;
+}
+
+- (instancetype)initWithMeta:(NSString *)meta
+                         api:(NSString *)api
+                     content:(NSString *)content
+             downloadContent:(NSString *)downloadContent
+                      notify:(NSString *)notify {
+  self = [self initWithMeta:meta api:api content:content notify:notify];
+  _downloadContent = downloadContent;
   return self;
 }
 
@@ -51,7 +62,11 @@
   case DBRouteHostApi:
     return [NSString stringWithFormat:@"https://%@/2", _api];
   case DBRouteHostContent:
-    return [NSString stringWithFormat:@"https://%@/2", _content];
+    if ([route.attrs[@"style"] isEqualToString:@"download"]) {
+        return [NSString stringWithFormat:@"https://%@/2", _downloadContent];
+    } else {
+        return [NSString stringWithFormat:@"https://%@/2", _content];
+    }
   case DBRouteHostNotify:
     return [NSString stringWithFormat:@"https://%@/2", _notify];
   case DBRouteHostUnknown:


### PR DESCRIPTION
**Download Content Host changes for ObjectiveDropbox**
Content host for download style request will be different than for upload style.
In order to reflect that, we added the downloadContentHost variable just for download style request.

Caller of this class will be able to pass in the host of their choice for download content host and the reason for that is we would like to utilize HTTP/2 benefits for download style requests if we want to.