### PR TITLE
Fix init in DBTransportBaseHostnameConfig

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseHostnameConfig.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseHostnameConfig.h
@@ -51,7 +51,9 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// @return An initialized instance with the provided hostname configuration
 ///
-- (instancetype)initWithMeta:(NSString *)meta api:(NSString *)api content:(NSString *)content downloadContent:(NSString *)downloadContent notify:(NSString *)notify;
+- (instancetype)initWithMeta:(NSString *)meta api:(NSString *)api content:(NSString *)content downloadContent:(NSString *)downloadContent notify:(NSString *)notify NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithMeta:(NSString *)meta api:(NSString *)api content:(NSString *)content notify:(NSString *)notify;
 
 ///
 /// Returns the prefix to use for API calls to the given route type.

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseHostnameConfig.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseHostnameConfig.h
@@ -46,14 +46,24 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param meta the hostname to metaserver
 /// @param api the hostname to api server
 /// @param content the hostname to content server
+/// @param notify the hostname to notify server
+///
+/// @return An initialized instance with the provided hostname configuration
+///
+- (instancetype)initWithMeta:(NSString *)meta api:(NSString *)api content:(NSString *)content notify:(NSString *)notify;
+
+///
+/// Constructor that takes in a set of custom hostnames to use for api calls.
+///
+/// @param meta the hostname to metaserver
+/// @param api the hostname to api server
+/// @param content the hostname to content server
 /// @param downloadContent the hostname to content server for download style
 /// @param notify the hostname to notify server
 ///
 /// @return An initialized instance with the provided hostname configuration
 ///
 - (instancetype)initWithMeta:(NSString *)meta api:(NSString *)api content:(NSString *)content downloadContent:(NSString *)downloadContent notify:(NSString *)notify NS_DESIGNATED_INITIALIZER;
-
-- (instancetype)initWithMeta:(NSString *)meta api:(NSString *)api content:(NSString *)content notify:(NSString *)notify;
 
 ///
 /// Returns the prefix to use for API calls to the given route type.

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseHostnameConfig.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseHostnameConfig.m
@@ -49,7 +49,7 @@
     _meta = meta;
     _api = api;
     _content = content;
-    _downloadContent = content;
+    _downloadContent = downloadContent;
     _notify = notify;
   }
   return self;

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseHostnameConfig.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseHostnameConfig.m
@@ -37,14 +37,7 @@
                          api:(NSString *)api
                      content:(NSString *)content
                       notify:(NSString *)notify {
-  if (self = [super init]) {
-    _meta = meta;
-    _api = api;
-    _content = content;
-    _downloadContent = content;
-    _notify = notify;
-  }
-  return self;
+    return [self initWithMeta:meta api:api content:content downloadContent:content notify:notify];
 }
 
 - (instancetype)initWithMeta:(NSString *)meta
@@ -52,8 +45,13 @@
                      content:(NSString *)content
              downloadContent:(NSString *)downloadContent
                       notify:(NSString *)notify {
-  self = [self initWithMeta:meta api:api content:content notify:notify];
-  _downloadContent = downloadContent;
+  if (self = [super init]) {
+    _meta = meta;
+    _api = api;
+    _content = content;
+    _downloadContent = content;
+    _notify = notify;
+  }
   return self;
 }
 


### PR DESCRIPTION
This is to fix the init issue that was caused by the last commit for adding downloadContentHost onto DBTransportBaseHostnameConfig.