### PR TITLE
Correct usage of assign for object type to use strong

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportClientProtocol.h
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportClientProtocol.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol DBTransportClient <NSObject>
 
 /// The Dropbox OAuth2 access token provider used to make requests.
-@property (nonatomic, nullable) id<DBAccessTokenProvider> accessTokenProvider;
+@property (nonatomic, nullable, strong) id<DBAccessTokenProvider> accessTokenProvider;
 
 #pragma mark - RPC-style request
 


### PR DESCRIPTION
This property should not be using `assign`, rather `strong`.

<img width="1260" alt="image" src="https://github.com/dropbox/dropbox-sdk-obj-c/assets/10729156/a51eaf76-04ca-41ca-9f01-aadc7c48a61b">
