### PR TITLE
Bump deployment targets and fix openUrl calls

### DIFF
--- a/ObjectiveDropboxOfficial.podspec
+++ b/ObjectiveDropboxOfficial.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   
   s.osx.deployment_target = '10.13'
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '12.0'
  
   s.public_header_files = 'Source/ObjectiveDropboxOfficial/Shared/**/*.h', 'Source/ObjectiveDropboxOfficial/Headers/Umbrella/*.h'
   s.osx.public_header_files = 'Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_macOS/**/*.h'

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Please ensure that the supplied view controller is the top-most controller, so t
   [DBClientsManager authorizeFromControllerV2:[UIApplication sharedApplication]
                                    controller:[[self class] topMostController]
                         loadingStatusDelegate:nil
-                                      openURL:^(NSURL *url) { [[UIApplication sharedApplication] openURL:url]; }
+                                      openURL:^(NSURL *url) { [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil]; }
                                  scopeRequest:scopeRequest];
 }
 

--- a/TestObjectiveDropbox/Podfile
+++ b/TestObjectiveDropbox/Podfile
@@ -1,7 +1,7 @@
 use_frameworks!
 
 target "TestObjectiveDropbox_iOS" do
-    platform :ios, '11.0'
+    platform :ios, '12.0'
     pod 'ObjectiveDropboxOfficial', :path => '../'
     target "TestObjectiveDropbox_iOSTests" do
         pod 'ObjectiveDropboxOfficial', :path => '../'
@@ -9,7 +9,7 @@ target "TestObjectiveDropbox_iOS" do
 end
 
 target "TestObjectiveDropbox_macOS" do
-    platform :osx, '10.10'
+    platform :osx, '10.13'
     pod 'ObjectiveDropboxOfficial', :path => '../'
     target "TestObjectiveDropbox_macOSTests" do
         pod 'ObjectiveDropboxOfficial', :path => '../'

--- a/TestObjectiveDropbox/TestObjectiveDropbox.xcodeproj/project.pbxproj
+++ b/TestObjectiveDropbox/TestObjectiveDropbox.xcodeproj/project.pbxproj
@@ -701,7 +701,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = TestObjectiveDropbox_macOSTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.getdropbox.TestObjectiveDropbox-macOSTests";
@@ -726,7 +726,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = TestObjectiveDropbox_macOSTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.getdropbox.TestObjectiveDropbox-macOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -793,7 +793,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = TestObjectiveDropbox_macOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dropbox.TestObjectiveDropbox-macOS-Test";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -811,7 +811,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = TestObjectiveDropbox_macOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dropbox.TestObjectiveDropbox-macOS-Test";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -935,7 +935,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = NX6T6UBSFF;
 				INFOPLIST_FILE = TestObjectiveDropbox_iOS/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dropbox.TestObjectiveDropbox-iOS-Test";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -953,7 +953,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = NX6T6UBSFF;
 				INFOPLIST_FILE = TestObjectiveDropbox_iOS/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dropbox.TestObjectiveDropbox-iOS-Test";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/TestObjectiveDropbox/TestObjectiveDropbox_iOS/AppDelegate.m
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_iOS/AppDelegate.m
@@ -75,7 +75,8 @@
   return YES;
 }
 
-- (BOOL)application:(UIApplication *)application handleOpenURL:(NSURL *)url {
+
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
   BOOL urlHandled = NO;
   if ([[url absoluteString] containsString:@"openWith"]) {
     NSLog(@"Successfully retrieved openWith url");
@@ -85,17 +86,17 @@
 
     for (NSString *pair in pairs) {
       NSArray *kv = [pair componentsSeparatedByString:@"="];
-      NSString *unEscapedValue = [[kv objectAtIndex:1] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+      NSString *unEscapedValue = [[kv objectAtIndex:1] stringByRemovingPercentEncoding];
       [urlData setObject:unEscapedValue forKey:[kv objectAtIndex:0]];
     }
 
-    DBOfficialAppConnector *connector = [[DBOfficialAppConnector alloc] initWithAppKey:[TestData new].fullDropboxAppKey
-                                                                     canOpenURLWrapper:^BOOL(NSURL *url) {
-                                                                       return [[UIApplication sharedApplication] canOpenURL:url];
-                                                                     }
-                                                                        openURLWrapper:^(NSURL *url) {
-                                                                          [[UIApplication sharedApplication] openURL:url];
-                                                                        }];
+      DBOfficialAppConnector *connector = [[DBOfficialAppConnector alloc] initWithAppKey:[TestData new].fullDropboxAppKey
+                                                                       canOpenURLWrapper:^BOOL(NSURL *url) {
+          return [[UIApplication sharedApplication] canOpenURL:url];
+      }
+                                                                          openURLWrapper:^(NSURL *url) {
+          [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
+      }];
 
     DBOpenWithInfo *openWithInfo = [connector openWithInfoFromURL:url];
     [((ViewController *)self.window.rootViewController) setOpenWithInfoNSURL:openWithInfo];

--- a/TestObjectiveDropbox/TestObjectiveDropbox_iOS/ViewController.m
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_iOS/ViewController.m
@@ -44,7 +44,9 @@ static DBOpenWithInfo *s_openWithInfoNSURL = nil;
   [DBClientsManager authorizeFromControllerV2:[UIApplication sharedApplication]
                                    controller:self
                         loadingStatusDelegate:nil
-                                      openURL:^(NSURL *url) { [[UIApplication sharedApplication] openURL:url]; }
+                                      openURL:^(NSURL *url) {
+      [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
+  }
                                  scopeRequest:scopeRequest];
 }
 
@@ -91,7 +93,7 @@ static DBOpenWithInfo *s_openWithInfoNSURL = nil;
         return [[UIApplication sharedApplication] canOpenURL:url];
     }
                                                                         openURLWrapper:^(NSURL *url) {
-        [[UIApplication sharedApplication] openURL:url];
+        [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
     }];
     DBOpenWithInfo *openWithInfo = [DBOfficialAppConnector retriveOfficialDropboxAppOpenWithInfo];
 
@@ -107,7 +109,7 @@ static DBOpenWithInfo *s_openWithInfoNSURL = nil;
             return [[UIApplication sharedApplication] canOpenURL:url];
         }
                                                                                openURLWrapper:^(NSURL *url) {
-            [[UIApplication sharedApplication] openURL:url];
+            [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
         }];
         [appConnector returnToDropboxApp:s_openWithInfoNSURL changesPending:NO];
     } else {


### PR DESCRIPTION
- openURL: without a completion handler will be a no-op in iOS 18, use new call.
- Bump iOS deployment target to Xcode 16 minimum supported, iOS 12.
- Update `TestObjectiveDropbox_macOS` deployment target to match pod spec macOS deployment target.