### PR TITLE
Remove secrets from GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,11 @@ jobs:
         run: |
           xcodebuild -workspace TestObjectiveDropbox/TestObjectiveDropbox.xcworkspace/ -scheme TestObjectiveDropbox_iOS -sdk iphonesimulator \
             -destination "platform=$platform,name=$device" \
-            build-without-testing
+            build-for-testing
       - name: Test macOS
         env:
           platform: macOS
         run: |
           xcodebuild -workspace TestObjectiveDropbox/TestObjectiveDropbox.xcworkspace/ -scheme TestObjectiveDropbox_macOS  \
             -destination "platform=$platform,arch=x86_64" \
-            build-without-testing
+            build-for-testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,48 +16,16 @@ jobs:
           pod install --repo-update
       - name: Test iOS
         env:
-          FULL_DROPBOX_API_APP_KEY: ${{ secrets.FULL_DROPBOX_API_APP_KEY }}
-          FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN: ${{ secrets.FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN }}
-          FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN: ${{ secrets.FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN }}
-          TEAM_MEMBER_EMAIL: ${{ secrets.TEAM_MEMBER_EMAIL }}
-          NON_TEAM_MEMBER_EMAIL: ${{ secrets.NON_TEAM_MEMBER_EMAIL }}
-          REFRESH_TOKEN_ACCOUNT_ID: ${{ secrets.REFRESH_TOKEN_ACCOUNT_ID }}
-          ANY_OTHER_ACCOUNT_ID: ${{ secrets.ANY_OTHER_ACCOUNT_ID }}
-          NON_TEAM_MEMBER_ACCOUNT_ID: ${{ secrets.NON_TEAM_MEMBER_ACCOUNT_ID }}
-          platform: ${{ 'iOS Simulator' }}
-          device: ${{ 'iPhone 16' }}
+          platform: 'iOS Simulator'
+          device: 'iPhone 16'
         run: |
           xcodebuild -workspace TestObjectiveDropbox/TestObjectiveDropbox.xcworkspace/ -scheme TestObjectiveDropbox_iOS -sdk iphonesimulator \
             -destination "platform=$platform,name=$device" \
-            FULL_DROPBOX_API_APP_KEY=$FULL_DROPBOX_API_APP_KEY \
-            FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN=$FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN \
-            FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN=$FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN \
-            TEAM_MEMBER_EMAIL=$TEAM_MEMBER_EMAIL \
-            NON_TEAM_MEMBER_EMAIL=$NON_TEAM_MEMBER_EMAIL \
-            REFRESH_TOKEN_ACCOUNT_ID=$REFRESH_TOKEN_ACCOUNT_ID \
-            ANY_OTHER_ACCOUNT_ID=$ANY_OTHER_ACCOUNT_ID \
-            NON_TEAM_MEMBER_ACCOUNT_ID=$NON_TEAM_MEMBER_ACCOUNT_ID \
-            test
+            build-without-testing
       - name: Test macOS
         env:
-          FULL_DROPBOX_API_APP_KEY: ${{ secrets.FULL_DROPBOX_API_APP_KEY }}
-          FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN: ${{ secrets.FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN }}
-          FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN: ${{ secrets.FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN }}
-          TEAM_MEMBER_EMAIL: ${{ secrets.TEAM_MEMBER_EMAIL }}
-          NON_TEAM_MEMBER_EMAIL: ${{ secrets.NON_TEAM_MEMBER_EMAIL }}
-          REFRESH_TOKEN_ACCOUNT_ID: ${{ secrets.REFRESH_TOKEN_ACCOUNT_ID }}
-          ANY_OTHER_ACCOUNT_ID: ${{ secrets.ANY_OTHER_ACCOUNT_ID }}
-          NON_TEAM_MEMBER_ACCOUNT_ID: ${{ secrets.NON_TEAM_MEMBER_ACCOUNT_ID }}
-          platform: ${{ 'macOS' }}
+          platform: macOS
         run: |
           xcodebuild -workspace TestObjectiveDropbox/TestObjectiveDropbox.xcworkspace/ -scheme TestObjectiveDropbox_macOS  \
             -destination "platform=$platform,arch=x86_64" \
-            FULL_DROPBOX_API_APP_KEY=$FULL_DROPBOX_API_APP_KEY \
-            FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN=$FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN \
-            FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN=$FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN \
-            TEAM_MEMBER_EMAIL=$TEAM_MEMBER_EMAIL \
-            NON_TEAM_MEMBER_EMAIL=$NON_TEAM_MEMBER_EMAIL \
-            REFRESH_TOKEN_ACCOUNT_ID=$REFRESH_TOKEN_ACCOUNT_ID \
-            ANY_OTHER_ACCOUNT_ID=$ANY_OTHER_ACCOUNT_ID \
-            NON_TEAM_MEMBER_ACCOUNT_ID=$NON_TEAM_MEMBER_ACCOUNT_ID \
-            test
+            build-without-testing

--- a/TestObjectiveDropbox/TestObjectiveDropbox.xcodeproj/xcshareddata/xcschemes/TestObjectiveDropbox_iOS.xcscheme
+++ b/TestObjectiveDropbox/TestObjectiveDropbox.xcodeproj/xcshareddata/xcschemes/TestObjectiveDropbox_iOS.xcscheme
@@ -36,48 +36,6 @@
             ReferencedContainer = "container:TestObjectiveDropbox.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "NON_TEAM_MEMBER_EMAIL"
-            value = "$(NON_TEAM_MEMBER_EMAIL)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "REFRESH_TOKEN_ACCOUNT_ID"
-            value = "$(REFRESH_TOKEN_ACCOUNT_ID)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "ANY_OTHER_ACCOUNT_ID"
-            value = "$(ANY_OTHER_ACCOUNT_ID)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "NON_TEAM_MEMBER_ACCOUNT_ID"
-            value = "$(NON_TEAM_MEMBER_ACCOUNT_ID)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "TEAM_MEMBER_EMAIL"
-            value = "$(TEAM_MEMBER_EMAIL)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN"
-            value = "$(FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN"
-            value = "$(FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "FULL_DROPBOX_API_APP_KEY"
-            value = "$(FULL_DROPBOX_API_APP_KEY)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/TestObjectiveDropbox/TestObjectiveDropbox.xcodeproj/xcshareddata/xcschemes/TestObjectiveDropbox_macOS.xcscheme
+++ b/TestObjectiveDropbox/TestObjectiveDropbox.xcodeproj/xcshareddata/xcschemes/TestObjectiveDropbox_macOS.xcscheme
@@ -36,48 +36,6 @@
             ReferencedContainer = "container:TestObjectiveDropbox.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "FULL_DROPBOX_API_APP_KEY"
-            value = "$(FULL_DROPBOX_API_APP_KEY)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "NON_TEAM_MEMBER_EMAIL"
-            value = "$(NON_TEAM_MEMBER_EMAIL)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "REFRESH_TOKEN_ACCOUNT_ID"
-            value = "$(REFRESH_TOKEN_ACCOUNT_ID)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "ANY_OTHER_ACCOUNT_ID"
-            value = "$(ANY_OTHER_ACCOUNT_ID)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "NON_TEAM_MEMBER_ACCOUNT_ID"
-            value = "$(NON_TEAM_MEMBER_ACCOUNT_ID)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "TEAM_MEMBER_EMAIL"
-            value = "$(TEAM_MEMBER_EMAIL)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN"
-            value = "$(FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN"
-            value = "$(FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
Per internal discussions, we are removing secure strings from GitHub Actions to align with our internal secret management policies. This changes the CI to build-only mode for the tests. Given this repo is effectively frozen, we'll have to make do with the minimal verification case.
