### PR TITLE
Run integration tests with scoped credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,17 @@
 name: CI
-on: [push, workflow_dispatch]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
-  test:
-    name: Run Unit tests
+  build:
+    name: Build tests
     runs-on: macos-latest
     timeout-minutes: 20
 
@@ -14,7 +22,7 @@ jobs:
         run: |
           cd TestObjectiveDropbox
           pod install --repo-update
-      - name: Test iOS
+      - name: Build iOS tests
         env:
           platform: 'iOS Simulator'
           device: 'iPhone 16'
@@ -22,10 +30,132 @@ jobs:
           xcodebuild -workspace TestObjectiveDropbox/TestObjectiveDropbox.xcworkspace/ -scheme TestObjectiveDropbox_iOS -sdk iphonesimulator \
             -destination "platform=$platform,name=$device" \
             build-for-testing
+      - name: Build macOS tests
+        env:
+          platform: macOS
+        run: |
+          xcodebuild -workspace TestObjectiveDropbox/TestObjectiveDropbox.xcworkspace/ -scheme TestObjectiveDropbox_macOS \
+            -destination "platform=$platform,arch=x86_64" \
+            build-for-testing
+
+  integration:
+    name: Run integration tests
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: macos-latest
+    timeout-minutes: 40
+    permissions:
+      id-token: write
+      contents: read
+    concurrency:
+      group: ${{ github.workflow }}-integration-tests
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Pod
+        run: |
+          cd TestObjectiveDropbox
+          pod install --repo-update
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::082972943155:role/oidc-github-dropbox-dropbox-sdk-obj-c-repo
+          aws-region: us-west-2
+      - name: Get integration credentials from AWS Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@v3
+        with:
+          secret-ids: |
+            CREDS,api-sdk-integration-test-creds
+          parse-json-secrets: true
+      - name: Discover integration test fixtures
+        run: |
+          set -euo pipefail
+          user_access_token=$(curl --fail --silent --show-error \
+            --user "$CREDS_SCOPED_USER_CLIENT_ID:$CREDS_SCOPED_USER_CLIENT_SECRET" \
+            --data grant_type=refresh_token \
+            --data refresh_token="$CREDS_SCOPED_USER_REFRESH_TOKEN" \
+            https://api.dropboxapi.com/oauth2/token | jq -r '.access_token')
+          team_access_token=$(curl --fail --silent --show-error \
+            --user "$CREDS_SCOPED_TEAM_CLIENT_ID:$CREDS_SCOPED_TEAM_CLIENT_SECRET" \
+            --data grant_type=refresh_token \
+            --data refresh_token="$CREDS_SCOPED_TEAM_REFRESH_TOKEN" \
+            https://api.dropboxapi.com/oauth2/token | jq -r '.access_token')
+
+          user_account=$(curl --fail --silent --show-error \
+            --request POST \
+            --header "Authorization: Bearer $user_access_token" \
+            --header 'Content-Type: application/json' \
+            --data '{}' \
+            https://api.dropboxapi.com/2/users/get_current_account)
+          team_member=$(curl --fail --silent --show-error \
+            --request POST \
+            --header "Authorization: Bearer $team_access_token" \
+            --header 'Content-Type: application/json' \
+            --data '{"limit":10}' \
+            https://api.dropboxapi.com/2/team/members/list_v2 | \
+            jq -c '[.members[] | select(.profile.status[".tag"] == "active") | .profile][0]')
+
+          user_account_id=$(jq -r '.account_id' <<<"$user_account")
+          user_account_email=$(jq -r '.email' <<<"$user_account")
+          team_member_account_id=$(jq -r '.account_id' <<<"$team_member")
+          team_member_email=$(jq -r '.email' <<<"$team_member")
+          test -n "$user_account_id"
+          test -n "$user_account_email"
+          test -n "$team_member_account_id"
+          test -n "$team_member_email"
+          test "$user_account_id" != null
+          test "$user_account_email" != null
+          test "$team_member_account_id" != null
+          test "$team_member_email" != null
+
+          echo "::add-mask::$user_account_id"
+          echo "::add-mask::$user_account_email"
+          echo "::add-mask::$team_member_account_id"
+          echo "::add-mask::$team_member_email"
+
+          credentials_file="$RUNNER_TEMP/dropbox-sdk-integration-creds.json"
+          umask 077
+          jq -n \
+            --arg user_client_id "$CREDS_SCOPED_USER_CLIENT_ID" \
+            --arg user_client_secret "$CREDS_SCOPED_USER_CLIENT_SECRET" \
+            --arg user_refresh_token "$CREDS_SCOPED_USER_REFRESH_TOKEN" \
+            --arg team_client_id "$CREDS_SCOPED_TEAM_CLIENT_ID" \
+            --arg team_client_secret "$CREDS_SCOPED_TEAM_CLIENT_SECRET" \
+            --arg team_refresh_token "$CREDS_SCOPED_TEAM_REFRESH_TOKEN" \
+            --arg user_account_id "$user_account_id" \
+            --arg team_member_account_id "$team_member_account_id" \
+            --arg user_account_email "$user_account_email" \
+            --arg team_member_email "$team_member_email" \
+            '{
+              SCOPED_USER_CLIENT_ID: $user_client_id,
+              SCOPED_USER_CLIENT_SECRET: $user_client_secret,
+              SCOPED_USER_REFRESH_TOKEN: $user_refresh_token,
+              SCOPED_TEAM_CLIENT_ID: $team_client_id,
+              SCOPED_TEAM_CLIENT_SECRET: $team_client_secret,
+              SCOPED_TEAM_REFRESH_TOKEN: $team_refresh_token,
+              REFRESH_TOKEN_ACCOUNT_ID: $user_account_id,
+              ANY_OTHER_ACCOUNT_ID: $team_member_account_id,
+              TEAM_MEMBER_EMAIL: $team_member_email,
+              SHARING_MEMBER_EMAIL: $team_member_email,
+              TEAM_SHARING_MEMBER_EMAIL: $user_account_email
+            }' > "$credentials_file"
+          chmod 600 "$credentials_file"
+          echo "SDK_TEST_CREDENTIALS_FILE=$credentials_file" >> "$GITHUB_ENV"
+      - name: Test iOS
+        env:
+          platform: 'iOS Simulator'
+          device: 'iPhone 16'
+        run: |
+          xcodebuild -workspace TestObjectiveDropbox/TestObjectiveDropbox.xcworkspace/ -scheme TestObjectiveDropbox_iOS -sdk iphonesimulator \
+            -destination "platform=$platform,name=$device" \
+            SDK_TEST_CREDENTIALS_FILE="$SDK_TEST_CREDENTIALS_FILE" \
+            test
       - name: Test macOS
         env:
           platform: macOS
         run: |
-          xcodebuild -workspace TestObjectiveDropbox/TestObjectiveDropbox.xcworkspace/ -scheme TestObjectiveDropbox_macOS  \
+          xcodebuild -workspace TestObjectiveDropbox/TestObjectiveDropbox.xcworkspace/ -scheme TestObjectiveDropbox_macOS \
             -destination "platform=$platform,arch=x86_64" \
-            build-for-testing
+            SDK_TEST_CREDENTIALS_FILE="$SDK_TEST_CREDENTIALS_FILE" \
+            test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build iOS tests
         env:
           platform: 'iOS Simulator'
-          device: 'iPhone 16'
+          device: 'iPhone 17'
         run: |
           xcodebuild -workspace TestObjectiveDropbox/TestObjectiveDropbox.xcworkspace/ -scheme TestObjectiveDropbox_iOS -sdk iphonesimulator \
             -destination "platform=$platform,name=$device" \
@@ -145,7 +145,7 @@ jobs:
       - name: Test iOS
         env:
           platform: 'iOS Simulator'
-          device: 'iPhone 16'
+          device: 'iPhone 17'
         run: |
           xcodebuild -workspace TestObjectiveDropbox/TestObjectiveDropbox.xcworkspace/ -scheme TestObjectiveDropbox_iOS -sdk iphonesimulator \
             -destination "platform=$platform,name=$device" \

--- a/TestObjectiveDropbox/IntegrationTests/TestClasses.m
+++ b/TestObjectiveDropbox/IntegrationTests/TestClasses.m
@@ -343,33 +343,14 @@ void MyLog(NSString *format, ...) {
         [TestFormat printTestEnd];
         nextTest();
     };
-// Comment this out until we understand the email_address_too_long_to_be_disabled error
-//    void (^membersRemove)(void) = ^{
-//        [teamTests membersRemove:end];
-//    };
-    void (^membersSetProfile)(void) = ^{
-        [teamTests membersSetProfile:end];
-    };
-    void (^membersSetAdminPermissions)(void) = ^{
-        [teamTests membersSetAdminPermissions:membersSetProfile];
-    };
-    void (^membersSendWelcomeEmail)(void) = ^{
-        [teamTests membersSendWelcomeEmail:membersSetAdminPermissions];
-    };
     void (^membersList)(void) = ^{
-        [teamTests membersList:membersSendWelcomeEmail];
+        [teamTests membersList:end];
     };
     void (^membersListDevices)(void) = ^{
         [teamTests membersListDevices:membersList];
     };
-    void (^membersGetInfo)(void) = ^{
-        [teamTests membersGetInfo:membersListDevices];
-    };
-    void (^membersAdd)(void) = ^{
-        [teamTests membersAdd:membersGetInfo];
-    };
     void (^groupsDelete)(void) = ^{
-        [teamTests groupsDelete:membersAdd];
+        [teamTests groupsDelete:membersListDevices];
     };
     void (^groupsUpdate)(void) = ^{
         [teamTests groupsUpdate:groupsDelete];

--- a/TestObjectiveDropbox/TestObjectiveDropbox.xcodeproj/xcshareddata/xcschemes/TestObjectiveDropbox_iOS.xcscheme
+++ b/TestObjectiveDropbox/TestObjectiveDropbox.xcodeproj/xcshareddata/xcschemes/TestObjectiveDropbox_iOS.xcscheme
@@ -36,6 +36,10 @@
             ReferencedContainer = "container:TestObjectiveDropbox.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable key = "SDK_TEST_CREDENTIALS_FILE" value = "$(SDK_TEST_CREDENTIALS_FILE)" isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/TestObjectiveDropbox/TestObjectiveDropbox.xcodeproj/xcshareddata/xcschemes/TestObjectiveDropbox_macOS.xcscheme
+++ b/TestObjectiveDropbox/TestObjectiveDropbox.xcodeproj/xcshareddata/xcschemes/TestObjectiveDropbox_macOS.xcscheme
@@ -36,6 +36,10 @@
             ReferencedContainer = "container:TestObjectiveDropbox.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable key = "SDK_TEST_CREDENTIALS_FILE" value = "$(SDK_TEST_CREDENTIALS_FILE)" isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/FileRoutesTests.m
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/FileRoutesTests.m
@@ -20,18 +20,20 @@
     // You can create one for testing here: https://www.dropbox.com/developers/apps/create
     // The 'App key' will be on the app's info page.
     // Then follow https://dropbox.tech/developers/pkce--what-and-why- to get a refresh token using the PKCE flow
-    NSString *apiAppKey = [TestAuthTokenGenerator environmentVariableForKey:@"FULL_DROPBOX_API_APP_KEY"];
+    NSString *apiAppKey = [TestAuthTokenGenerator credentialForKey:@"SCOPED_USER_CLIENT_ID"];
+    NSString *apiAppSecret = [TestAuthTokenGenerator credentialForKey:@"SCOPED_USER_CLIENT_SECRET"];
 
     DBAccessToken *fileRoutesTestsAuthToken = [TestAuthTokenGenerator
-                                          refreshToken:[TestAuthTokenGenerator environmentVariableForKey:@"FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN"]
+                                          refreshToken:[TestAuthTokenGenerator credentialForKey:@"SCOPED_USER_REFRESH_TOKEN"]
                                           apiKey:apiAppKey
+                                          apiSecret:apiAppSecret
                                           scopes:[DropboxTester scopesForTests]];
     XCTAssertNotNil(fileRoutesTestsAuthToken, @"Error obtaining auth token.");
 
     _delegateQueue = [[NSOperationQueue alloc] init];
     DBTransportDefaultConfig *transportConfigFullDropbox =
       [[DBTransportDefaultConfig alloc] initWithAppKey:apiAppKey
-                                             appSecret:nil // not needed
+                                             appSecret:apiAppSecret
                                              userAgent:nil
                                             asMemberId:nil
                                          delegateQueue:_delegateQueue
@@ -47,12 +49,9 @@
     _userClient = [self createUserClient];
 
     TestData * data = [[TestData alloc] init];
-    data.teamMemberEmail = [TestAuthTokenGenerator environmentVariableForKey:@"TEAM_MEMBER_EMAIL"];
-    data.teamMemberNewEmail = [TestAuthTokenGenerator environmentVariableForKey:@"NON_TEAM_MEMBER_EMAIL"];
-    data.accountId = [TestAuthTokenGenerator environmentVariableForKey:@"REFRESH_TOKEN_ACCOUNT_ID"];
-    data.accountId2 = [TestAuthTokenGenerator environmentVariableForKey:@"ANY_OTHER_ACCOUNT_ID"];
-    data.accountId3 = [TestAuthTokenGenerator environmentVariableForKey:@"NON_TEAM_MEMBER_ACCOUNT_ID"];
-    data.accountId3Email = data.teamMemberNewEmail;
+    data.accountId = [TestAuthTokenGenerator credentialForKey:@"REFRESH_TOKEN_ACCOUNT_ID"];
+    data.accountId2 = [TestAuthTokenGenerator credentialForKey:@"ANY_OTHER_ACCOUNT_ID"];
+    data.accountId3Email = [TestAuthTokenGenerator credentialForKey:@"SHARING_MEMBER_EMAIL"];
     
     _tester = [[DropboxTester alloc] initWithUserClient:_userClient testData:data];
     _testData = data;

--- a/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/TeamRoutesTests.m
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/TeamRoutesTests.m
@@ -17,12 +17,10 @@
     _teamClient = [self createTeamClient];
 
     TestData * data = [[TestData alloc] init];
-    data.teamMemberEmail = [TestAuthTokenGenerator environmentVariableForKey:@"TEAM_MEMBER_EMAIL"];
-    data.teamMemberNewEmail = [TestAuthTokenGenerator environmentVariableForKey:@"NON_TEAM_MEMBER_EMAIL"];
-    data.accountId = [TestAuthTokenGenerator environmentVariableForKey:@"REFRESH_TOKEN_ACCOUNT_ID"];
-    data.accountId2 = [TestAuthTokenGenerator environmentVariableForKey:@"ANY_OTHER_ACCOUNT_ID"];
-    data.accountId3 = [TestAuthTokenGenerator environmentVariableForKey:@"NON_TEAM_MEMBER_ACCOUNT_ID"];
-    data.accountId3Email = data.teamMemberNewEmail;
+    data.teamMemberEmail = [TestAuthTokenGenerator credentialForKey:@"TEAM_MEMBER_EMAIL"];
+    data.accountId = [TestAuthTokenGenerator credentialForKey:@"REFRESH_TOKEN_ACCOUNT_ID"];
+    data.accountId2 = [TestAuthTokenGenerator credentialForKey:@"ANY_OTHER_ACCOUNT_ID"];
+    data.accountId3Email = [TestAuthTokenGenerator credentialForKey:@"TEAM_SHARING_MEMBER_EMAIL"];
     
     _teamTester = [[DropboxTeamTester alloc] initWithTeamClient:_teamClient testData:data];
 }
@@ -33,17 +31,19 @@
     // The 'App key' will be on the app's info page.
     // Then follow https://dropbox.tech/developers/pkce--what-and-why- to get a refresh token using the PKCE flow
 
-    NSString *apiAppKey = [TestAuthTokenGenerator environmentVariableForKey:@"FULL_DROPBOX_API_APP_KEY"];
+    NSString *apiAppKey = [TestAuthTokenGenerator credentialForKey:@"SCOPED_TEAM_CLIENT_ID"];
+    NSString *apiAppSecret = [TestAuthTokenGenerator credentialForKey:@"SCOPED_TEAM_CLIENT_SECRET"];
     DBAccessToken *teamRoutesTestsAuthToken = [TestAuthTokenGenerator
-                                          refreshToken:[TestAuthTokenGenerator environmentVariableForKey:@"FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN"]
+                                          refreshToken:[TestAuthTokenGenerator credentialForKey:@"SCOPED_TEAM_REFRESH_TOKEN"]
                                           apiKey:apiAppKey
+                                          apiSecret:apiAppSecret
                                           scopes:[DropboxTeamTester scopesForTests]];
     XCTAssertNotNil(teamRoutesTestsAuthToken, @"Errors obtaining auth token.");
 
     _delegateQueue = [[NSOperationQueue alloc] init];
     DBTransportDefaultConfig *transportConfigFullDropbox =
       [[DBTransportDefaultConfig alloc] initWithAppKey:apiAppKey
-                                             appSecret:nil // not needed
+                                             appSecret:apiAppSecret
                                              userAgent:nil
                                             asMemberId:nil
                                          delegateQueue:_delegateQueue

--- a/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/TestAuthTokenGenerator.h
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/TestAuthTokenGenerator.h
@@ -1,9 +1,10 @@
 @class DBAccessToken;
 
 @interface TestAuthTokenGenerator : NSObject
-+ (nonnull NSString *)environmentVariableForKey:(nonnull NSString *)key;
++ (nonnull NSString *)credentialForKey:(nonnull NSString *)key;
 
 + (nullable DBAccessToken *)refreshToken:(nullable NSString *)refreshToken
-                             apiKey:(nullable NSString *)apiKey
-                             scopes:(nonnull NSArray<NSString *>*)scopes;
+                                  apiKey:(nullable NSString *)apiKey
+                               apiSecret:(nullable NSString *)apiSecret
+                                  scopes:(nonnull NSArray<NSString *> *)scopes;
 @end

--- a/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/TestAuthTokenGenerator.m
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_iOSTests/TestAuthTokenGenerator.m
@@ -4,19 +4,26 @@
 
 @implementation TestAuthTokenGenerator
 
-+ (NSString *)environmentVariableForKey:(NSString *)key {
-    NSDictionary<NSString *, NSString *> *processInfoDict = [[NSProcessInfo processInfo] environment];
-    NSString *value = processInfoDict[key];
-    XCTAssertNotNil(value, @"%@ environment variable must exist", key);
-    XCTAssertNotEqual(value.length, 0, @"%@ environment variable must be longer than 0", key);
-    XCTAssertFalse([value hasSuffix:@" "], @"%@ environment variable value must not end in whitespace", key);
++ (NSString *)credentialForKey:(NSString *)key {
+    NSString *credentialsPath = [NSProcessInfo processInfo].environment[@"SDK_TEST_CREDENTIALS_FILE"];
+    XCTAssertNotEqual(credentialsPath.length, 0, @"SDK_TEST_CREDENTIALS_FILE environment variable must exist");
+    NSData *credentialsData = [NSData dataWithContentsOfFile:credentialsPath];
+    XCTAssertNotNil(credentialsData, @"Unable to read SDK test credentials file");
+    NSDictionary<NSString *, NSString *> *credentials =
+        credentialsData ? [NSJSONSerialization JSONObjectWithData:credentialsData options:0 error:nil] : nil;
+    XCTAssertTrue([credentials isKindOfClass:[NSDictionary class]], @"SDK test credentials file must contain JSON");
+    NSString *value = credentials[key];
+    XCTAssertNotNil(value, @"%@ must exist in SDK test credentials file", key);
+    XCTAssertNotEqual(value.length, 0, @"%@ must be longer than 0", key);
+    XCTAssertFalse([value hasSuffix:@" "], @"%@ must not end in whitespace", key);
     return value;
 }
 
 // Easy way for all tests to get an auth token for the scopes they use.
 + (nullable DBAccessToken *)refreshToken:(nullable NSString *)refreshToken
-                             apiKey:(nullable NSString *)apiKey
-                             scopes:(nonnull NSArray<NSString *>*)scopes {
+                                  apiKey:(nullable NSString *)apiKey
+                               apiSecret:(nullable NSString *)apiSecret
+                                  scopes:(nonnull NSArray<NSString *> *)scopes {
     XCTAssertNotEqual(refreshToken.length, 0, @"Error: refreshToken needs to be set");
     if (refreshToken.length == 0) {
         return nil;
@@ -25,27 +32,62 @@
     if(apiKey.length == 0) {
         return nil;
     }
+    XCTAssertNotEqual(apiSecret.length, 0, @"Error: api secret needs to be set");
+    if (apiSecret.length == 0) {
+        return nil;
+    }
 
-    DBAccessToken *defaultToken = [[DBAccessToken alloc]
-                                   initWithAccessToken:@"" // no previous token
-                                   uid:@"" // don't need uid
-                                   refreshToken:refreshToken
-                                   tokenExpirationTimestamp:0];
+    NSURLComponents *bodyComponents = [[NSURLComponents alloc] init];
+    bodyComponents.queryItems = @[
+        [NSURLQueryItem queryItemWithName:@"grant_type" value:@"refresh_token"],
+        [NSURLQueryItem queryItemWithName:@"refresh_token" value:refreshToken],
+        [NSURLQueryItem queryItemWithName:@"scope" value:[scopes componentsJoinedByString:@" "]],
+    ];
+
+    NSMutableURLRequest *request =
+        [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"https://api.dropboxapi.com/oauth2/token"]];
+    request.HTTPMethod = @"POST";
+    request.HTTPBody = [bodyComponents.percentEncodedQuery dataUsingEncoding:NSUTF8StringEncoding];
+    [request setValue:@"application/x-www-form-urlencoded; charset=utf-8" forHTTPHeaderField:@"Content-Type"];
+
+    NSString *credentials = [NSString stringWithFormat:@"%@:%@", apiKey, apiSecret];
+    NSData *credentialsData = [credentials dataUsingEncoding:NSUTF8StringEncoding];
+    NSString *basicAuth = [credentialsData base64EncodedStringWithOptions:0];
+    [request setValue:[NSString stringWithFormat:@"Basic %@", basicAuth] forHTTPHeaderField:@"Authorization"];
 
     XCTestExpectation *flag = [[XCTestExpectation alloc] init];
-    DBOAuthManager *manager = [[DBOAuthManager alloc] initWithAppKey:apiKey];
     __block DBAccessToken *authToken = nil;
-    [manager refreshAccessToken:defaultToken
-                         scopes:scopes
-                          queue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0)
-                     completion:^(DBOAuthResult * result) {
-        if(!result.isSuccess) {
-            XCTFail(@"Error: failed to refresh access token (%@)", result.errorDescription);
+    NSURLSessionDataTask *task = [[NSURLSession sharedSession]
+        dataTaskWithRequest:request
+          completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        if (error) {
+            XCTFail(@"Error: failed to refresh access token (%@)", error.localizedDescription);
+            [flag fulfill];
+            return;
+        }
+
+        NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+        NSDictionary<NSString *, id> *result =
+            data ? [NSJSONSerialization JSONObjectWithData:data options:0 error:nil] : nil;
+        NSString *accessToken = [result[@"access_token"] isKindOfClass:[NSString class]] ? result[@"access_token"] : nil;
+        NSNumber *expiresIn = [result[@"expires_in"] isKindOfClass:[NSNumber class]] ? result[@"expires_in"] : nil;
+        if (httpResponse.statusCode != 200 || accessToken.length == 0 || expiresIn == nil) {
+            NSString *errorDescription =
+                [result[@"error_description"] isKindOfClass:[NSString class]] ? result[@"error_description"] : @"Invalid response";
+            XCTFail(@"Error: failed to refresh access token (HTTP %ld: %@)", (long)httpResponse.statusCode,
+                    errorDescription);
         } else {
-            authToken = result.accessToken;
+            NSString *uid = [result[@"uid"] isKindOfClass:[NSString class]] ? result[@"uid"] : @"";
+            NSTimeInterval expiration = [[NSDate date] timeIntervalSince1970] + expiresIn.doubleValue;
+            authToken = [[DBAccessToken alloc] initWithAccessToken:accessToken
+                                                               uid:uid
+                                                      refreshToken:refreshToken
+                                          tokenExpirationTimestamp:expiration];
         }
         [flag fulfill];
     }];
+    [task resume];
+
     XCTWaiterResult result = [XCTWaiter waitForExpectations:@[flag] timeout:10];
     XCTAssertEqual(result, XCTWaiterResultCompleted, @"Error: Timeout refreshing access token");
     return authToken;

--- a/TestObjectiveDropbox/TestObjectiveDropbox_macOS/AppDelegate.m
+++ b/TestObjectiveDropbox/TestObjectiveDropbox_macOS/AppDelegate.m
@@ -23,6 +23,11 @@ static ViewController *viewController = nil;
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
     if([[NSProcessInfo processInfo] environment][@"XCTestConfigurationFilePath"] != nil) {
         // running unit tests
+        // The storyboard's default button can otherwise receive an activation event while
+        // XCTest is launching the host app and start the legacy manual test flow in parallel.
+        for (NSWindow *window in [NSApplication sharedApplication].windows) {
+            window.contentViewController = [[NSViewController alloc] init];
+        }
         return;
     }
 


### PR DESCRIPTION
## What changed

- authenticate integration CI through GitHub OIDC and AWS Secrets Manager
- run the existing iOS and macOS integration tests with scoped user and team refresh tokens
- pass credentials to XCTest through a mode-0600 JSON file instead of individual Xcode build settings
- derive account and sharing fixtures from the shared test accounts at runtime
- keep team-management coverage reversible and prevent the macOS host's manual test action from running during XCTest

## Why

The Objective-C integration tests existed but CI only built them, and their legacy credential names did not match the shared SDK integration-test secret. Passing credentials individually through Xcode also records them in result bundles.

This aligns the repository with the OIDC and shared-secret approach used by the Python SDK while keeping credentials out of Xcode result metadata.

## Validation

- macOS live integration suite: 3 tests, 0 failures (57.2 seconds)
- isolated user-route integration test: passed (26.1 seconds)
- workflow YAML parsed successfully
- shared Xcode schemes passed XML validation
- `git diff --check`

iOS execution was not run locally because the installed Xcode has no iOS simulator runtime; CI retains iOS build and test coverage.
