### PR TITLE
Install stone dependencies in spec_update workflow

### DIFF
--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -37,6 +37,10 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install packaging ply six
       - name: Get current time
         uses: 1466587594/get-current-time@v2
         id: current-time


### PR DESCRIPTION
## Summary
- Install `packaging`, `ply`, and `six` before running `generate_base_client.py`
- These are required by the stone submodule at runtime but aren't installed automatically since we use stone directly from the submodule rather than via pip

Fixes the `ModuleNotFoundError: No module named 'packaging'` failure in https://github.com/dropbox/dropbox-sdk-obj-c/actions/runs/29862950007

## Test plan
- [ ] Re-trigger `spec_update` workflow and confirm generation completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)