### PR TITLE
Run spec_update workflow on macos-latest

### DIFF
--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   Update:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6


### PR DESCRIPTION
## Summary
- Switch `spec_update` workflow from `ubuntu-latest` to `macos-latest`
- `generate_base_client.py` calls `Format/format_files.sh` which runs `clang-format` but exits early on non-Darwin systems, causing unformatted whitespace changes in the generated PR

## Test plan
- [ ] Re-trigger `spec_update` workflow and confirm generated code has no spurious whitespace changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)