### PR TITLE
Install clang-format in spec_update workflow

### DIFF
--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -37,6 +37,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
+      - name: Install clang-format
+        run: brew install clang-format
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- Install `clang-format` via Homebrew before generation
- `Format/format_files.sh` requires clang-format >= 7, which isn't pre-installed on the macOS GitHub runner

## Test plan
- [ ] Re-trigger `spec_update` workflow and confirm formatting runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)