### PR TITLE
Run clang-format on existing source files

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobileManager-iOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobileManager-iOS.m
@@ -91,8 +91,8 @@ static NSString *kDBLinkNonce = @"dropbox.sync.nonce";
   NSURLComponents *components = [self db_dauthUrlCommonComponentsWithScheme:scheme];
   if (nonce != nil) {
     NSString *state = [NSString stringWithFormat:@"oauth2:%@", nonce];
-    components.queryItems =
-        [components.queryItems arrayByAddingObject:[NSURLQueryItem queryItemWithName:kDBStateKey value:state]];
+    components.queryItems = [components.queryItems arrayByAddingObject:[NSURLQueryItem queryItemWithName:kDBStateKey
+                                                                                                   value:state]];
   }
   return components.URL;
 }

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/DBAppClient.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/DBAppClient.m
@@ -9,14 +9,15 @@
 @implementation DBAppClient
 
 - (instancetype)initWithAppKey:(NSString *)appKey appSecret:(NSString *)appSecret {
-  DBTransportDefaultConfig *transportConfig =
-      [[DBTransportDefaultConfig alloc] initWithAppKey:appKey appSecret:appSecret];
+  DBTransportDefaultConfig *transportConfig = [[DBTransportDefaultConfig alloc] initWithAppKey:appKey
+                                                                                     appSecret:appSecret];
   return [self initWithTransportConfig:transportConfig];
 }
 
 - (instancetype)initWithTransportConfig:(DBTransportDefaultConfig *)transportConfig {
-  DBTransportDefaultClient *transportClient =
-      [[DBTransportDefaultClient alloc] initWithAccessToken:nil tokenUid:nil transportConfig:transportConfig];
+  DBTransportDefaultClient *transportClient = [[DBTransportDefaultClient alloc] initWithAccessToken:nil
+                                                                                           tokenUid:nil
+                                                                                    transportConfig:transportConfig];
   return [super initWithTransportClient:transportClient];
 }
 

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBDelegate.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBDelegate.m
@@ -191,8 +191,10 @@
   BOOL success = YES;
 
   if (![fileManager fileExistsAtPath:tmpDirPath isDirectory:&isDir]) {
-    success =
-        [fileManager createDirectoryAtPath:tmpDirPath withIntermediateDirectories:YES attributes:nil error:fileError];
+    success = [fileManager createDirectoryAtPath:tmpDirPath
+                     withIntermediateDirectories:YES
+                                      attributes:nil
+                                           error:fileError];
   }
 
   if (success) {

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasks.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasks.m
@@ -309,8 +309,8 @@
     NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
     int statusCode = (int)httpResponse.statusCode;
     NSDictionary *httpHeaders = httpResponse.allHeaderFields;
-    id headerString =
-        [DBTransportBaseClient caseInsensitiveLookupWithKey:@"Dropbox-API-Result" headerFieldsDictionary:httpHeaders];
+    id headerString = [DBTransportBaseClient caseInsensitiveLookupWithKey:@"Dropbox-API-Result"
+                                                   headerFieldsDictionary:httpHeaders];
 
     NSData *resultData = nil;
     if ([headerString isKindOfClass:[NSString class]]) {
@@ -445,8 +445,8 @@
     NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
     int statusCode = (int)httpResponse.statusCode;
     NSDictionary *httpHeaders = httpResponse.allHeaderFields;
-    id headerString =
-        [DBTransportBaseClient caseInsensitiveLookupWithKey:@"Dropbox-API-Result" headerFieldsDictionary:httpHeaders];
+    id headerString = [DBTransportBaseClient caseInsensitiveLookupWithKey:@"Dropbox-API-Result"
+                                                   headerFieldsDictionary:httpHeaders];
 
     NSData *resultData = nil;
     if ([headerString isKindOfClass:[NSString class]]) {
@@ -479,8 +479,9 @@
     } else {
       NSError *serializationError;
       @try {
-        result =
-            [DBTransportBaseClient routeResultWithRoute:route data:resultData serializationError:&serializationError];
+        result = [DBTransportBaseClient routeResultWithRoute:route
+                                                        data:resultData
+                                          serializationError:&serializationError];
       } @catch (NSException *exception) {
         serializationError = [[strongSelf class] dropboxBadResponseErrorWithException:exception];
       }

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasksImpl.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTasksImpl.m
@@ -57,8 +57,9 @@
 }
 
 - (DBTask *)restart {
-  DBRpcTaskImpl *sdkTask =
-      [[DBRpcTaskImpl alloc] initWithTask:[_task duplicate] tokenUid:self.tokenUid route:self.route];
+  DBRpcTaskImpl *sdkTask = [[DBRpcTaskImpl alloc] initWithTask:[_task duplicate]
+                                                      tokenUid:self.tokenUid
+                                                         route:self.route];
   sdkTask.retryCount += 1;
   [sdkTask setResponseBlock:_responseBlock queue:_queue];
   [sdkTask resume];
@@ -137,8 +138,9 @@
 }
 
 - (DBTask *)restart {
-  DBUploadTaskImpl *sdkTask =
-      [[DBUploadTaskImpl alloc] initWithTask:[_uploadTask duplicate] tokenUid:self.tokenUid route:self.route];
+  DBUploadTaskImpl *sdkTask = [[DBUploadTaskImpl alloc] initWithTask:[_uploadTask duplicate]
+                                                            tokenUid:self.tokenUid
+                                                               route:self.route];
   sdkTask.retryCount += 1;
   [sdkTask setResponseBlock:_responseBlock queue:_queue];
   [sdkTask resume];

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseClient.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseClient.m
@@ -403,8 +403,9 @@ static NSLock *kAsciiEscapeSelectorLock;
   if (!route.resultType) {
     return nil;
   }
-  id jsonData =
-      [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:serializationError];
+  id jsonData = [NSJSONSerialization JSONObjectWithData:data
+                                                options:NSJSONReadingMutableContainers
+                                                  error:serializationError];
   if (*serializationError) {
     return nil;
   }

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseConfig.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportBaseConfig.m
@@ -36,8 +36,11 @@
                      appSecret:(NSString *)appSecret
                      userAgent:(NSString *)userAgent
                     asMemberId:(NSString *)asMemberId {
-  return
-      [self initWithAppKey:appKey appSecret:appSecret userAgent:userAgent asMemberId:asMemberId additionalHeaders:nil];
+  return [self initWithAppKey:appKey
+                    appSecret:appSecret
+                    userAgent:userAgent
+                   asMemberId:asMemberId
+            additionalHeaders:nil];
 }
 
 - (instancetype)initWithAppKey:(NSString *)appKey

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportDefaultClient.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBTransportDefaultClient.m
@@ -50,8 +50,9 @@
     NSOperationQueue *sessionDelegateQueue =
         [self urlSessionDelegateQueueWithName:[NSString stringWithFormat:@"%@ NSURLSession delegate queue",
                                                                          NSStringFromClass(self.class)]];
-    _session =
-        [NSURLSession sessionWithConfiguration:sessionConfig delegate:_delegate delegateQueue:sessionDelegateQueue];
+    _session = [NSURLSession sessionWithConfiguration:sessionConfig
+                                             delegate:_delegate
+                                        delegateQueue:sessionDelegateQueue];
     _forceForegroundSession = transportConfig.forceForegroundSession ? YES : NO;
     if (!_forceForegroundSession) {
       NSString *backgroundId =
@@ -115,8 +116,10 @@
     NSDictionary *headers = [self headersWithRouteInfo:route.attrs serializedArg:serializedArg];
     // RPC request submits argument in request body
     NSData *serializedArgData = [[self class] serializeDataWithRoute:route routeArg:arg];
-    NSURLRequest *request =
-        [[self class] requestWithHeaders:headers url:requestUrl content:serializedArgData stream:nil];
+    NSURLRequest *request = [[self class] requestWithHeaders:headers
+                                                         url:requestUrl
+                                                     content:serializedArgData
+                                                      stream:nil];
     return [sessionToUse dataTaskWithRequest:request];
   };
 
@@ -148,8 +151,9 @@
                                                                urlSession:sessionToUse
                                                             tokenProvider:self.accessTokenProvider];
 
-  DBUploadTaskImpl *uploadTask =
-      [[DBUploadTaskImpl alloc] initWithTask:taskWithTokenRefresh tokenUid:self.tokenUid route:route];
+  DBUploadTaskImpl *uploadTask = [[DBUploadTaskImpl alloc] initWithTask:taskWithTokenRefresh
+                                                               tokenUid:self.tokenUid
+                                                                  route:route];
   [uploadTask resume];
   return uploadTask;
 }
@@ -173,8 +177,9 @@
                                                                urlSession:sessionToUse
                                                             tokenProvider:self.accessTokenProvider];
 
-  DBUploadTaskImpl *uploadTask =
-      [[DBUploadTaskImpl alloc] initWithTask:taskWithTokenRefresh tokenUid:self.tokenUid route:route];
+  DBUploadTaskImpl *uploadTask = [[DBUploadTaskImpl alloc] initWithTask:taskWithTokenRefresh
+                                                               tokenUid:self.tokenUid
+                                                                  route:route];
   [uploadTask resume];
   return uploadTask;
 }
@@ -195,8 +200,9 @@
                                                              taskDelegate:_delegate
                                                                urlSession:sessionToUse
                                                             tokenProvider:self.accessTokenProvider];
-  DBUploadTaskImpl *uploadTask =
-      [[DBUploadTaskImpl alloc] initWithTask:taskWithTokenRefresh tokenUid:self.tokenUid route:route];
+  DBUploadTaskImpl *uploadTask = [[DBUploadTaskImpl alloc] initWithTask:taskWithTokenRefresh
+                                                               tokenUid:self.tokenUid
+                                                                  route:route];
   [uploadTask resume];
   return uploadTask;
 }
@@ -274,8 +280,9 @@
                                                              taskDelegate:_delegate
                                                                urlSession:sessionToUse
                                                             tokenProvider:self.accessTokenProvider];
-  DBDownloadDataTaskImpl *downloadTask =
-      [[DBDownloadDataTaskImpl alloc] initWithTask:taskWithTokenRefresh tokenUid:self.tokenUid route:route];
+  DBDownloadDataTaskImpl *downloadTask = [[DBDownloadDataTaskImpl alloc] initWithTask:taskWithTokenRefresh
+                                                                             tokenUid:self.tokenUid
+                                                                                route:route];
   [downloadTask resume];
   return downloadTask;
 }

--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBOAuthManager.m
@@ -191,47 +191,46 @@ static DBOAuthManager *s_sharedOAuthManager;
     NSString *title = NSLocalizedString(@"No internet connection",
                                         @"Displayed when commencing authorization flow without internet connection.");
 
-    NSDictionary<NSString *, void (^)(void)> *buttonHandlers = @{
-      @"Cancel" : ^{
+    NSDictionary<NSString *, void (^)(void)> *buttonHandlers = @{@"Cancel" : ^{
         cancelHandler();
-      },
-      @"Retry" : ^{
-        [self authorizeFromSharedApplication:sharedApplication usePkce:usePkce scopeRequest:scopeRequest];
-      }
-    };
-
-    [sharedApplication presentErrorMessageWithHandlers:message title:title buttonHandlers:buttonHandlers];
-
-    return;
   }
-
-  if (![self conformsToAppScheme]) {
-    NSString *message = [NSString stringWithFormat:@"DropboxSDK: unable to link; app isn't registered for correct URL "
-                                                   @"scheme (db-%@). Add this scheme to your project Info.plist file, "
-                                                   @"associated with following key: \"Information Property List\" > "
-                                                   @"\"URL types\" > \"Item 0\" > \"URL Schemes\" > \"Item <N>\".",
-                                                   _appKey];
-    NSString *title = @"DropboxSDK Error";
-
-    [sharedApplication presentErrorMessage:message title:title];
-
-    return;
+  , @"Retry" : ^{
+    [self authorizeFromSharedApplication:sharedApplication usePkce:usePkce scopeRequest:scopeRequest];
   }
+};
 
-  if (usePkce) {
-    _authSession = [[DBOAuthPKCESession alloc] initWithScopeRequest:scopeRequest];
-  } else {
-    _authSession = nil;
-  }
-  _sharedApplication = sharedApplication;
+[sharedApplication presentErrorMessageWithHandlers:message title:title buttonHandlers:buttonHandlers];
 
-  NSURL *authUrl = [self authURL];
+return;
+}
 
-  if ([self checkAndPresentPlatformSpecificAuth:sharedApplication]) {
-    return;
-  }
+if (![self conformsToAppScheme]) {
+  NSString *message = [NSString stringWithFormat:@"DropboxSDK: unable to link; app isn't registered for correct URL "
+                                                 @"scheme (db-%@). Add this scheme to your project Info.plist file, "
+                                                 @"associated with following key: \"Information Property List\" > "
+                                                 @"\"URL types\" > \"Item 0\" > \"URL Schemes\" > \"Item <N>\".",
+                                                 _appKey];
+  NSString *title = @"DropboxSDK Error";
 
-  [sharedApplication presentAuthChannel:authUrl cancelHandler:cancelHandler];
+  [sharedApplication presentErrorMessage:message title:title];
+
+  return;
+}
+
+if (usePkce) {
+  _authSession = [[DBOAuthPKCESession alloc] initWithScopeRequest:scopeRequest];
+} else {
+  _authSession = nil;
+}
+_sharedApplication = sharedApplication;
+
+NSURL *authUrl = [self authURL];
+
+if ([self checkAndPresentPlatformSpecificAuth:sharedApplication]) {
+  return;
+}
+
+[sharedApplication presentAuthChannel:authUrl cancelHandler:cancelHandler];
 }
 
 - (BOOL)conformsToAppScheme {
@@ -361,8 +360,8 @@ static DBOAuthManager *s_sharedOAuthManager;
       } else if (parametersMap[kDBUidKey] && parametersMap[@"access_token"]) {
         // Token flow
         NSString *uid = parametersMap[kDBUidKey];
-        DBAccessToken *accessToken =
-            [DBAccessToken createWithLongLivedAccessToken:parametersMap[@"access_token"] uid:uid];
+        DBAccessToken *accessToken = [DBAccessToken createWithLongLivedAccessToken:parametersMap[@"access_token"]
+                                                                               uid:uid];
         completion([[DBOAuthResult alloc] initWithSuccess:accessToken]);
       } else {
         completion([DBOAuthResult unknownErrorWithErrorDescription:@"Invalid response."]);


### PR DESCRIPTION
## Summary
- Run `Format/format_files.sh Source` to format the 10 handwritten Obj-C files that had drifted from the `.clang-format` config
- This ensures future automated spec updates don't include unrelated whitespace changes in the diff

## Test plan
- [ ] CI passes (formatting-only change, no logic changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)